### PR TITLE
:tada: Add lint and type checking rules (refs #24)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.0
+    hooks:
+      - id: ruff
+        # args: ["--fix"]
+        exclude: ^(examples/)
+
+  - repo: local
+    hooks:
+      - id: run-pyright
+        name: pyright
+        entry: pyright
+        language: system
+        types: [python]
+        exclude: ^(examples/)
+
+      - id: run-pytest
+        name: pytest
+        entry: pytest tests
+        language: system
+        types: [python]
+        exclude: ^(examples/)

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,16 @@
+{
+    "include": [
+      "projects"
+    ],
+    "exclude": [
+      "**/venv",
+      "**/.venv",
+      "**/__pycache__",
+      "examples",
+    ],
+    "typeCheckingMode": "standard",
+    "reportUnusedVariable": "warning",
+    "reportMissingImports": "error",
+    "reportUnknownMemberType": "warning",
+    "useLibraryCodeForTypes": true
+  }

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,23 @@
+line-length = 88
+
+[lint]
+select = [
+  "D",
+  "E", "W",
+  "F",
+  "ARG",
+  "I",
+]
+ignore = [
+  "E501", 
+  "F821",
+  "F722",
+  "D107" # missing docstring in __init__
+]
+
+[lint.pydocstyle]
+convention = "google"
+
+[lint.per-file-ignores]
+"*tests/*" = ["D", "S101"]
+"__init__.py" = ["F401"]


### PR DESCRIPTION
Adds:
- `ruff.toml` for linting rules
- `pyrightconfig.json` for type checking rules

It also adds `pre-commit-config.yaml` that can be used after installing `pre-commit`. It runs ruff, pyright, and pytest locally, and you can run it as follows:
```
pre-commit run --all-files
```
If in addition you do `pre-commit install`, then the hooks will be executed automatically each time you commit something 🚀 

We can add an action that runs ruff and pyright once we agree with the chosen rules.