### PR TITLE
♻️ Remove manual trigger

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,7 +1,6 @@
 name: Publish to PyPI
 
 on:
-  workflow_dispatch:
   release:
     types: [created]
 


### PR DESCRIPTION
Removes:
* the manual trigger in the PyPI publishing workflow