### PR TITLE
📄 Documentation: replace title home page with a blank line

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,8 +3,9 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-PLAID documentation
-===================
+.. raw:: html
+
+    <br>
 
 .. image:: https://plaid-lib.github.io/assets/images/PLAID-large-logo.png
    :align: center


### PR DESCRIPTION
To prevent this repetition
![image](https://github.com/user-attachments/assets/329c55a5-487c-4052-94a7-73cd417c8f36)
