### PR TITLE
♻️ Add conftest and refactorize fixtures

### DIFF
--- a/tests/bridges/test_huggingface_bridge.py
+++ b/tests/bridges/test_huggingface_bridge.py
@@ -7,18 +7,16 @@
 
 # %% Imports
 
-import pytest
 import pickle
-
-from plaid.containers.dataset import Dataset
-from plaid.containers.sample import Sample
-from plaid.bridges import huggingface_bridge
-from plaid.problem_definition import ProblemDefinition
-
 from typing import Callable
 
-from ..containers.test_dataset import samples, other_samples, infos, nb_samples
-from ..containers.test_sample import base_name, zone_name
+import pytest
+
+from plaid.bridges import huggingface_bridge
+from plaid.containers.dataset import Dataset
+from plaid.containers.sample import Sample
+from plaid.problem_definition import ProblemDefinition
+
 
 # %% Fixtures
 @pytest.fixture()
@@ -33,7 +31,7 @@ def dataset(samples, infos) -> Dataset:
 def problem_definition() -> ProblemDefinition:
     problem_definition = ProblemDefinition()
     problem_definition.set_task("regression")
-    problem_definition.add_input_scalars_names(['feature_name_1','feature_name_2'])
+    problem_definition.add_input_scalars_names(["feature_name_1", "feature_name_2"])
     return problem_definition
 
 
@@ -42,33 +40,33 @@ def generator(dataset) -> Callable:
     def generator():
         for id in range(len(dataset)):
             yield {
-                "sample" : pickle.dumps(dataset[id]),
+                "sample": pickle.dumps(dataset[id]),
             }
+
     return generator
 
 
 @pytest.fixture()
 def hf_dataset(generator, infos, problem_definition) -> Dataset:
-    hf_dataset = huggingface_bridge.plaid_generator_to_huggingface(generator, infos, problem_definition)
+    hf_dataset = huggingface_bridge.plaid_generator_to_huggingface(
+        generator, infos, problem_definition
+    )
     return hf_dataset
 
 
-class Test_Huggingface_Bridge():
-
+class Test_Huggingface_Bridge:
     def assert_hf_dataset(self, hfds):
-        assert hfds.description['legal'] == {'owner': 'PLAID2', 'license': 'BSD-3'}
-        assert hfds.description['task'] == "regression"
-        assert hfds.description['in_scalars_names'][0] == "feature_name_1"
-        assert hfds.description['in_scalars_names'][1] == "feature_name_2"
-        self.assert_sample(Sample.model_validate(pickle.loads(hfds[0]['sample'])))
-
+        assert hfds.description["legal"] == {"owner": "PLAID2", "license": "BSD-3"}
+        assert hfds.description["task"] == "regression"
+        assert hfds.description["in_scalars_names"][0] == "feature_name_1"
+        assert hfds.description["in_scalars_names"][1] == "feature_name_2"
+        self.assert_sample(Sample.model_validate(pickle.loads(hfds[0]["sample"])))
 
     def assert_plaid_dataset(self, ds, pbdef):
-        assert ds.get_infos()['legal'] == {'owner': 'PLAID2', 'license': 'BSD-3'}
+        assert ds.get_infos()["legal"] == {"owner": "PLAID2", "license": "BSD-3"}
         assert pbdef.get_input_scalars_names()[0] == "feature_name_1"
         assert pbdef.get_input_scalars_names()[1] == "feature_name_2"
         self.assert_sample(ds[0])
-
 
     def assert_sample(self, sample):
         assert isinstance(sample, Sample)
@@ -76,43 +74,36 @@ class Test_Huggingface_Bridge():
         assert "test_field_same_size" in sample.get_field_names()
         assert sample.get_field("test_field_same_size").shape[0] == 17
 
-
     def test_plaid_dataset_to_huggingface(self, dataset, problem_definition):
         hfds = huggingface_bridge.plaid_dataset_to_huggingface(
-            dataset,
-            problem_definition
-            )
+            dataset, problem_definition
+        )
         self.assert_hf_dataset(hfds)
-
 
     def test_plaid_generator_to_huggingface(self, generator, infos, problem_definition):
         hfds = huggingface_bridge.plaid_generator_to_huggingface(
-            generator,
-            infos,
-            problem_definition
-            )
+            generator, infos, problem_definition
+        )
         self.assert_hf_dataset(hfds)
-
 
     def test_huggingface_dataset_to_plaid(self, hf_dataset):
         ds, pbdef = huggingface_bridge.huggingface_dataset_to_plaid(hf_dataset)
         self.assert_plaid_dataset(ds, pbdef)
 
-
     def test_create_string_for_huggingface_dataset_card(self, hf_dataset):
         huggingface_bridge.create_string_for_huggingface_dataset_card(
-        description = hf_dataset.description,
-        download_size_bytes = 10,
-        dataset_size_bytes = 10,
-        nb_samples = 10,
-        owner = "Safran",
-        license = "cc-by-sa-4.0",
-        zenodo_url = "https://zenodo.org/records/10124594",
-        arxiv_paper_url = "https://arxiv.org/pdf/2305.12871",
-        pretty_name = "2D quasistatic non-linear structural mechanics solutions",
-        size_categories = ["n<1K"],
-        task_categories = ["graph-ml"],
-        tags = ["physics learning", "geometry learning"],
-        dataset_long_description = "my long description",
-        url_illustration = "url3"
+            description=hf_dataset.description,
+            download_size_bytes=10,
+            dataset_size_bytes=10,
+            nb_samples=10,
+            owner="Safran",
+            license="cc-by-sa-4.0",
+            zenodo_url="https://zenodo.org/records/10124594",
+            arxiv_paper_url="https://arxiv.org/pdf/2305.12871",
+            pretty_name="2D quasistatic non-linear structural mechanics solutions",
+            size_categories=["n<1K"],
+            task_categories=["graph-ml"],
+            tags=["physics learning", "geometry learning"],
+            dataset_long_description="my long description",
+            url_illustration="url3",
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,63 @@
+"""This file defines shared pytest fixtures and test configurations."""
+
+import numpy as np
+import pytest
+
+from plaid.containers.sample import Sample
+
+
+def generate_samples(nb: int, zone_name: str, base_name: str) -> list[Sample]:
+    """Generate a list of Sample objects with randomized scalar and field data."""
+    sample_list = []
+    for _ in range(nb):
+        sample = Sample()
+        sample.init_base(3, 3, base_name)
+        sample.init_zone(np.array([0, 0, 0]), zone_name=zone_name, base_name=base_name)
+        sample.add_scalar("test_scalar", np.random.randn())
+        sample.add_field(
+            "test_field_same_size", np.random.randn(17), zone_name, base_name
+        )
+        sample.add_field(
+            f"test_field_{np.random.randint(1e8, 1e9)}",
+            np.random.randn(np.random.randint(10, 20)),
+            zone_name,
+            base_name,
+        )
+        sample_list.append(sample)
+    return sample_list
+
+
+@pytest.fixture()
+def nb_samples() -> int:
+    """Number of samples to generate for tests."""
+    return 11
+
+
+@pytest.fixture()
+def base_name() -> str:
+    """Base name for initializing samples' base hierarchy."""
+    return "TestBaseName"
+
+
+@pytest.fixture()
+def zone_name() -> str:
+    """Zone name for initializing samples' zone hierarchy."""
+    return "TestZoneName"
+
+
+@pytest.fixture()
+def samples(nb_samples: int, zone_name: str, base_name: str) -> list[Sample]:
+    """A fixture providing a list of generated Sample objects."""
+    return generate_samples(nb_samples, zone_name, base_name)
+
+
+@pytest.fixture()
+def other_samples(nb_samples: int, zone_name: str, base_name: str) -> list[Sample]:
+    """An alternate fixture providing a different list of Sample objects."""
+    return generate_samples(nb_samples, zone_name, base_name)
+
+
+@pytest.fixture()
+def infos() -> dict:
+    """Legal metadata used in test datasets."""
+    return {"legal": {"owner": "PLAID2", "license": "BSD-3"}}

--- a/tests/containers/test_dataset.py
+++ b/tests/containers/test_dataset.py
@@ -7,34 +7,22 @@
 
 # %% Imports
 
-import pytest
-
 from pathlib import Path
+
 import numpy as np
+import pytest
 
 import plaid
 from plaid.containers.dataset import Dataset
 from plaid.containers.sample import Sample
 from plaid.utils.base import ShapeError
 
-from .test_sample import base_name, zone_name
-
 # %% Fixtures
-
-
-@pytest.fixture()
-def nb_samples():
-    return 11
 
 
 @pytest.fixture()
 def nb_scalars():
     return 5
-
-
-@pytest.fixture()
-def infos():
-    return {"legal": {"owner": "PLAID2", "license": "BSD-3"}}
 
 
 @pytest.fixture()
@@ -44,8 +32,7 @@ def tabular(nb_samples, nb_scalars):
 
 @pytest.fixture()
 def scalar_names(nb_scalars):
-    return [
-        f'test_scalar_{np.random.randint(1e8,1e9)}' for _ in range(nb_scalars)]
+    return [f"test_scalar_{np.random.randint(1e8, 1e9)}" for _ in range(nb_scalars)]
 
 
 @pytest.fixture()
@@ -53,71 +40,15 @@ def sample(zone_name, base_name):
     sample = Sample()
     sample.init_base(3, 3, base_name)
     sample.init_zone(np.array([0, 0, 0]), zone_name=zone_name, base_name=base_name)
-    sample.add_scalar('test_scalar', np.random.randn())
+    sample.add_scalar("test_scalar", np.random.randn())
+    sample.add_field("test_field_same_size", np.random.randn(17), zone_name, base_name)
     sample.add_field(
-        'test_field_same_size',
-        np.random.randn(17),
+        f"test_field_{np.random.randint(1e8, 1e9)}",
+        np.random.randn(np.random.randint(10, 20)),
         zone_name,
-        base_name)
-    sample.add_field(
-        f'test_field_{np.random.randint(1e8,1e9)}',
-        np.random.randn(
-            np.random.randint(
-                10,
-                20)),
-        zone_name,
-        base_name)
+        base_name,
+    )
     return sample
-
-
-@pytest.fixture()
-def samples(nb_samples, zone_name, base_name):
-    samples = []
-    for _ in range(nb_samples):
-        sample = Sample()
-        sample.init_base(3, 3, base_name)
-        sample.init_zone(np.array([0, 0, 0]), zone_name=zone_name, base_name=base_name)
-        sample.add_scalar('test_scalar', np.random.randn())
-        sample.add_field(
-            'test_field_same_size',
-            np.random.randn(17),
-            zone_name,
-            base_name)
-        sample.add_field(
-            f'test_field_{np.random.randint(1e8,1e9)}',
-            np.random.randn(
-                np.random.randint(
-                    10,
-                    20)),
-            zone_name,
-            base_name)
-        samples.append(sample)
-    return samples
-
-
-@pytest.fixture()
-def other_samples(nb_samples, zone_name, base_name):
-    other_samples = []
-    for _ in range(nb_samples):
-        sample = Sample()
-        sample.init_base(3, 3, base_name)
-        sample.init_zone(np.array([0, 0, 0]), zone_name=zone_name, base_name=base_name)
-        sample.add_scalar('test_scalar', np.random.randn())
-        sample.add_field(
-            'test_field_same_size',
-            np.random.randn(17),
-            zone_name,
-            base_name)
-        sample.add_field(
-            f'test_field_{np.random.randint(1e8,1e9)}',
-            np.random.randn(
-                np.random.randint(
-                    10,
-                    20)),
-            zone_name,
-            base_name)
-        other_samples.append(sample)
-    return other_samples
 
 
 @pytest.fixture
@@ -153,24 +84,30 @@ def other_dataset_with_samples(other_samples):
     other_dataset.add_samples(other_samples)
     return other_dataset
 
+
 def compare_two_samples(sample_1: Sample, sample_2: Sample):
     assert set(sample_1.get_all_mesh_times()) == set(sample_2.get_all_mesh_times())
     assert set(sample_1.get_scalar_names()) == set(sample_2.get_scalar_names())
     assert set(sample_1.get_field_names()) == set(sample_2.get_field_names())
-    assert set(sample_1.get_time_series_names()) == set(sample_2.get_time_series_names())
+    assert set(sample_1.get_time_series_names()) == set(
+        sample_2.get_time_series_names()
+    )
     assert np.array_equal(sample_1.get_nodes(), sample_2.get_nodes())
     assert set(sample_1.get_base_names()) == set(sample_2.get_base_names())
     for base_name in sample_1.get_base_names():
-        assert set(sample_1.get_zone_names(base_name)) == set(sample_2.get_zone_names(base_name))
+        assert set(sample_1.get_zone_names(base_name)) == set(
+            sample_2.get_zone_names(base_name)
+        )
         for zone_name in sample_1.get_zone_names(base_name):
-            assert sample_1.get_zone_type(zone_name, base_name) == sample_2.get_zone_type(zone_name, base_name)
+            assert sample_1.get_zone_type(
+                zone_name, base_name
+            ) == sample_2.get_zone_type(zone_name, base_name)
 
 
 # %% Tests
 
 
-class Test_Dataset():
-
+class Test_Dataset:
     # -------------------------------------------------------------------------#
     def test___init__(self, dataset):
         assert len(dataset) == 0
@@ -201,18 +138,14 @@ class Test_Dataset():
     # -------------------------------------------------------------------------#
     def test_get_samples(self, dataset_with_samples, nb_samples):
         dataset_with_samples.get_samples()
-        dataset_with_samples.get_samples(
-            np.arange(np.random.randint(2, nb_samples)))
+        dataset_with_samples.get_samples(np.arange(np.random.randint(2, nb_samples)))
         dataset_with_samples.get_samples(as_list=True)
         dataset_with_samples.get_samples(
-            np.arange(
-                np.random.randint(
-                    2,
-                    nb_samples)),
-            as_list=True)
+            np.arange(np.random.randint(2, nb_samples)), as_list=True
+        )
 
     def test_add_sample(self, dataset, sample):
-        assert (dataset.add_sample(sample) == 0)
+        assert dataset.add_sample(sample) == 0
         assert len(dataset) == 1
 
     def test_del_sample_classical(self, dataset, sample):
@@ -305,8 +238,10 @@ class Test_Dataset():
 
     def test_add_samples(self, dataset_with_samples, other_samples):
         size_before = len(dataset_with_samples)
-        assert ((dataset_with_samples.add_samples(other_samples) == np.arange(
-            size_before, size_before + len(other_samples))).all())
+        assert (
+            dataset_with_samples.add_samples(other_samples)
+            == np.arange(size_before, size_before + len(other_samples))
+        ).all()
 
     def test_add_samples_not_a_list_of_samples(self, dataset, sample):
         with pytest.raises(TypeError):
@@ -380,8 +315,7 @@ class Test_Dataset():
     # -------------------------------------------------------------------------#
     def test_get_scalar_names(self, dataset_with_samples, nb_samples):
         dataset_with_samples.get_scalar_names()
-        dataset_with_samples.get_scalar_names(
-            np.random.randint(2, nb_samples, size=2))
+        dataset_with_samples.get_scalar_names(np.random.randint(2, nb_samples, size=2))
 
     def test_get_scalar_names_same_ids(self, dataset_with_samples, nb_samples):
         dataset_with_samples.get_scalar_names()
@@ -389,52 +323,46 @@ class Test_Dataset():
 
     def test_get_field_names(self, dataset_with_samples, nb_samples):
         dataset_with_samples.get_field_names()
-        dataset_with_samples.get_field_names(
-            np.random.randint(2, nb_samples, size=2))
+        dataset_with_samples.get_field_names(np.random.randint(2, nb_samples, size=2))
 
     # -------------------------------------------------------------------------#
-    def test_add_tabular_scalars(
-            self, dataset, tabular, scalar_names, nb_samples):
+    def test_add_tabular_scalars(self, dataset, tabular, scalar_names, nb_samples):
         dataset.add_tabular_scalars(tabular, scalar_names)
-        assert (len(dataset) == nb_samples)
+        assert len(dataset) == nb_samples
 
     def test_add_tabular_scalars_no_names(self, dataset, tabular, nb_samples):
         dataset.add_tabular_scalars(tabular)
-        assert (len(dataset) == nb_samples)
+        assert len(dataset) == nb_samples
 
-    def test_add_tabular_scalars_bad_ndim(
-            self, dataset, tabular, scalar_names):
+    def test_add_tabular_scalars_bad_ndim(self, dataset, tabular, scalar_names):
         with pytest.raises(ShapeError):
             dataset.add_tabular_scalars(tabular.reshape((-1)), scalar_names)
 
-    def test_add_tabular_scalars_bad_shape(
-            self, dataset, tabular, scalar_names):
-        tabular = np.concatenate(
-            (tabular, np.zeros((len(tabular), 1))), axis=1)
+    def test_add_tabular_scalars_bad_shape(self, dataset, tabular, scalar_names):
+        tabular = np.concatenate((tabular, np.zeros((len(tabular), 1))), axis=1)
         with pytest.raises(ShapeError):
             dataset.add_tabular_scalars(tabular, scalar_names)
 
     def test_get_scalars_to_tabular(self, dataset, tabular, scalar_names):
-        assert (len(dataset.get_scalars_to_tabular()) == 0)
-        assert (dataset.get_scalars_to_tabular() == {})
+        assert len(dataset.get_scalars_to_tabular()) == 0
+        assert dataset.get_scalars_to_tabular() == {}
         dataset.add_tabular_scalars(tabular, scalar_names)
-        assert (
-            dataset.get_scalars_to_tabular(
-                as_nparray=True).shape == (
-                len(tabular),
-                len(scalar_names)))
+        assert dataset.get_scalars_to_tabular(as_nparray=True).shape == (
+            len(tabular),
+            len(scalar_names),
+        )
         dict_tabular = dataset.get_scalars_to_tabular()
         for i_s, sname in enumerate(scalar_names):
-            assert (np.all(dict_tabular[sname] == tabular[:, i_s]))
+            assert np.all(dict_tabular[sname] == tabular[:, i_s])
 
     def test_get_scalars_to_tabular_same_scalars_name(
-            self, dataset, tabular, scalar_names):
+        self, dataset, tabular, scalar_names
+    ):
         dataset.add_tabular_scalars(tabular, scalar_names)
-        assert (
-            dataset.get_scalars_to_tabular(
-                as_nparray=True).shape == (
-                len(tabular),
-                len(scalar_names)))
+        assert dataset.get_scalars_to_tabular(as_nparray=True).shape == (
+            len(tabular),
+            len(scalar_names),
+        )
         dataset.get_scalars_to_tabular(sample_ids=[0, 0])
         dataset.get_scalars_to_tabular(scalar_names=["test", "test"])
 
@@ -448,15 +376,15 @@ class Test_Dataset():
         dataset.add_info("legal", "owner", "PLAID2")
 
     def test_add_infos(self, dataset):
-        infos = {"legal":{"owner":"CompX", "license":"li_X"}}
+        infos = {"legal": {"owner": "CompX", "license": "li_X"}}
         dataset.set_infos(infos)
-        new_info = {"type":"simulation", "simulator":"Z-set"}
+        new_info = {"type": "simulation", "simulator": "Z-set"}
         dataset.add_infos("data_production", new_info)
-        dataset.add_infos("legal", {"owner":"CompY", "license":"li_Y"})
+        dataset.add_infos("legal", {"owner": "CompY", "license": "li_Y"})
         with pytest.raises(KeyError):
             dataset.add_infos("illegal_category_key", new_info)
         with pytest.raises(KeyError):
-            illegal_info = {"z":"simulation", "e":"Z-set"}
+            illegal_info = {"z": "simulation", "e": "Z-set"}
             dataset.add_infos("data_production", illegal_info)
         dataset.add_info("legal", "owner", "PLAID2")
 
@@ -465,26 +393,25 @@ class Test_Dataset():
         dataset.set_infos(infos)
         with pytest.raises(KeyError):
             dataset.set_infos(
-                {"illegal_category_key": {"owner": "PLAID2", "license": "BSD-3"}})
+                {"illegal_category_key": {"owner": "PLAID2", "license": "BSD-3"}}
+            )
         with pytest.raises(KeyError):
             dataset.set_infos(
-                {"legal": {"illegal_info_key": "PLAID2", "license": "BSD-3"}})
+                {"legal": {"illegal_info_key": "PLAID2", "license": "BSD-3"}}
+            )
 
     def test_get_infos(self, dataset):
-        assert (dataset.get_infos() == {})
+        assert dataset.get_infos() == {}
 
     def test_print_infos(self, dataset, infos):
         dataset.set_infos(infos)
         dataset.print_infos()
 
     # -------------------------------------------------------------------------#
-    def test_merge_dataset(self, dataset_with_samples,
-                           other_dataset_with_samples):
+    def test_merge_dataset(self, dataset_with_samples, other_dataset_with_samples):
         init_len = len(dataset_with_samples)
         dataset_with_samples.merge_dataset(other_dataset_with_samples)
-        assert (
-            len(dataset_with_samples) == init_len +
-            len(other_dataset_with_samples))
+        assert len(dataset_with_samples) == init_len + len(other_dataset_with_samples)
 
     def test_merge_dataset_with_None(self, dataset_with_samples):
         dataset_with_samples.merge_dataset(None)
@@ -496,81 +423,83 @@ class Test_Dataset():
     # -------------------------------------------------------------------------#
 
     def test_save(self, dataset_with_samples, tmp_path):
-        fname = tmp_path / 'test.plaid'
+        fname = tmp_path / "test.plaid"
         dataset_with_samples.save(fname)
         assert fname.is_file()
 
     def test_load(self, dataset_with_samples, tmp_path):
-        fname = tmp_path / 'test.plaid'
+        fname = tmp_path / "test.plaid"
         dataset_with_samples.save(fname)
         new_dataset = Dataset()
         new_dataset.load(fname)
-        assert (len(new_dataset) == len(dataset_with_samples))
+        assert len(new_dataset) == len(dataset_with_samples)
         for sample_1, sample_2 in zip(dataset_with_samples, new_dataset):
             compare_two_samples(sample_1, sample_2)
 
         n_dataset = Dataset(str(fname))
-        assert (len(n_dataset) == len(dataset_with_samples))
+        assert len(n_dataset) == len(dataset_with_samples)
         for sample_1, sample_2 in zip(dataset_with_samples, n_dataset):
             compare_two_samples(sample_1, sample_2)
 
     def test_load_multiprocessing(self, dataset_with_samples, tmp_path):
-        fname = tmp_path / 'test.plaid'
+        fname = tmp_path / "test.plaid"
         dataset_with_samples.save(fname)
 
         new_dataset = Dataset()
         new_dataset.load(fname)
         multi_process_new_dataset = Dataset()
-        multi_process_new_dataset.load(fname, processes_number = 3)
-        assert (len(new_dataset) == len(multi_process_new_dataset))
+        multi_process_new_dataset.load(fname, processes_number=3)
+        assert len(new_dataset) == len(multi_process_new_dataset)
         for sample_1, sample_2 in zip(multi_process_new_dataset, new_dataset):
             compare_two_samples(sample_1, sample_2)
 
         n_dataset = Dataset(str(fname))
-        multi_process_n_dataset = Dataset(str(fname), processes_number = 0)
-        assert (len(n_dataset) == len(multi_process_n_dataset))
+        multi_process_n_dataset = Dataset(str(fname), processes_number=0)
+        assert len(n_dataset) == len(multi_process_n_dataset)
         for sample_1, sample_2 in zip(multi_process_n_dataset, n_dataset):
             compare_two_samples(sample_1, sample_2)
 
         loaded_dataset = Dataset.load_from_file(fname)
-        multi_process_loaded_dataset = Dataset.load_from_file(fname, processes_number = -1)
-        assert (len(loaded_dataset) == len(multi_process_loaded_dataset))
+        multi_process_loaded_dataset = Dataset.load_from_file(
+            fname, processes_number=-1
+        )
+        assert len(loaded_dataset) == len(multi_process_loaded_dataset)
         for sample_1, sample_2 in zip(multi_process_loaded_dataset, loaded_dataset):
             compare_two_samples(sample_1, sample_2)
 
     def test_load_process_eror(self, dataset_with_samples, tmp_path):
-        fname = tmp_path / 'test.plaid'
+        fname = tmp_path / "test.plaid"
         dataset_with_samples.save(fname)
         with pytest.raises(ValueError):
-            Dataset(str(fname), processes_number = -3)
+            Dataset(str(fname), processes_number=-3)
 
     def test_load_from_file(self, dataset_with_samples, tmp_path):
-        fname = tmp_path / 'test_fname.plaid'
+        fname = tmp_path / "test_fname.plaid"
         dataset_with_samples.save(fname)
         loaded_dataset = Dataset.load_from_file(fname)
-        assert (len(loaded_dataset) == len(dataset_with_samples))
+        assert len(loaded_dataset) == len(dataset_with_samples)
 
     def test_load_from_dir(self, dataset_with_samples, tmp_path):
-        dname = tmp_path / 'test_dname'
+        dname = tmp_path / "test_dname"
         dataset_with_samples._save_to_dir_(dname)
         loaded_dataset = Dataset.load_from_dir(dname)
-        assert (len(loaded_dataset) == len(dataset_with_samples))
+        assert len(loaded_dataset) == len(dataset_with_samples)
 
     # -------------------------------------------------------------------------#
     def test__save_to_dir_(self, dataset_with_samples, tmp_path):
-        savedir = tmp_path / 'testdir'
+        savedir = tmp_path / "testdir"
         dataset_with_samples._save_to_dir_(savedir)
         assert plaid.get_number_of_samples(savedir) == len(dataset_with_samples)
         assert savedir.is_dir()
-        assert (savedir / 'infos.yaml').is_file()
+        assert (savedir / "infos.yaml").is_file()
 
     def test__load_from_dir_(self, dataset_with_samples, infos, tmp_path):
-        savedir = tmp_path / 'testdir'
+        savedir = tmp_path / "testdir"
         dataset_with_samples._save_to_dir_(savedir)
         new_dataset = Dataset()
         new_dataset._load_from_dir_(savedir)
-        assert (len(new_dataset) == len(dataset_with_samples))
-        assert (new_dataset.get_infos() == infos)
+        assert len(new_dataset) == len(dataset_with_samples)
+        assert new_dataset.get_infos() == infos
         for sample_1, sample_2 in zip(dataset_with_samples, new_dataset):
             compare_two_samples(sample_1, sample_2)
 
@@ -589,7 +518,7 @@ class Test_Dataset():
 
     def test_set_samples_not_an_int(self, dataset, sample):
         with pytest.raises(TypeError):
-            dataset.set_samples({'0': sample})
+            dataset.set_samples({"0": sample})
 
     def test_set_samples_not_positive(self, dataset, sample):
         with pytest.raises(ValueError):
@@ -605,7 +534,7 @@ class Test_Dataset():
 
     def test_set_sample_not_an_int(self, dataset, sample):
         with pytest.raises(TypeError):
-            dataset.set_sample('0', sample)
+            dataset.set_sample("0", sample)
 
     def test_set_sample_not_positive(self, dataset, sample):
         with pytest.raises(ValueError):
@@ -617,10 +546,10 @@ class Test_Dataset():
 
     # -------------------------------------------------------------------------#
     def test___len__empty(self, dataset):
-        assert (len(dataset) == 0)
+        assert len(dataset) == 0
 
     def test___len__(self, dataset_with_samples, nb_samples):
-        assert (len(dataset_with_samples) == nb_samples)
+        assert len(dataset_with_samples) == nb_samples
 
     def test___getitem__empty(self, dataset):
         with pytest.raises(IndexError):

--- a/tests/containers/test_sample.py
+++ b/tests/containers/test_sample.py
@@ -11,7 +11,6 @@ import os
 
 import CGNS.PAT.cgnskeywords as CGK
 import CGNS.PAT.cgnsutils as CGU
-import CGNS.PAT.cgnslib as CGL
 import numpy as np
 import pytest
 from Muscat.Bridges.CGNSBridge import MeshToCGNS
@@ -23,11 +22,6 @@ from plaid.containers.sample import Sample, show_cgns_tree
 
 
 @pytest.fixture()
-def base_name():
-    return 'TestBaseName'
-
-
-@pytest.fixture()
 def topological_dim():
     return 2
 
@@ -35,11 +29,6 @@ def topological_dim():
 @pytest.fixture()
 def physical_dim():
     return 3
-
-
-@pytest.fixture()
-def zone_name():
-    return 'TestZoneName'
 
 
 @pytest.fixture()
@@ -59,57 +48,63 @@ def other_sample():
 
 @pytest.fixture()
 def sample_with_scalar(sample):
-    sample.add_scalar('test_scalar_1', np.random.randn())
+    sample.add_scalar("test_scalar_1", np.random.randn())
     return sample
 
 
 @pytest.fixture()
 def sample_with_time_series(sample):
     sample.add_time_series(
-        'test_time_series_1',
-        np.arange(
-            111,
-            dtype=float),
-        np.random.randn(111))
+        "test_time_series_1", np.arange(111, dtype=float), np.random.randn(111)
+    )
     return sample
 
 
 @pytest.fixture()
 def nodes():
-    return np.array([
-        [0.0, 0.0],
-        [1.0, 0.0],
-        [1.0, 1.0],
-        [0.0, 1.0],
-        [0.5, 1.5],
-    ])
+    return np.array(
+        [
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [1.0, 1.0],
+            [0.0, 1.0],
+            [0.5, 1.5],
+        ]
+    )
 
 
 @pytest.fixture()
 def nodes3d():
-    return np.array([
-        [0.0, 0.0, 0.0],
-        [1.0, 0.0, 0.0],
-        [1.0, 1.0, 0.0],
-        [0.0, 1.0, 0.0],
-        [0.5, 1.5, 1.0],
-    ])
+    return np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.5, 1.5, 1.0],
+        ]
+    )
 
 
 @pytest.fixture()
 def nodal_tags():
-    return np.array([
-        0, 1,
-    ])
+    return np.array(
+        [
+            0,
+            1,
+        ]
+    )
 
 
 @pytest.fixture()
 def triangles():
-    return np.array([
-        [0, 1, 2],
-        [0, 2, 3],
-        [2, 4, 3],
-    ])
+    return np.array(
+        [
+            [0, 1, 2],
+            [0, 2, 3],
+            [2, 4, 3],
+        ]
+    )
 
 
 @pytest.fixture()
@@ -126,9 +121,9 @@ def cell_center_field():
 def tree(nodes, triangles, vertex_field, cell_center_field, nodal_tags):
     Mesh = MCT.CreateMeshOfTriangles(nodes, triangles)
     Mesh.GetNodalTag("tag").AddToTag(nodal_tags)
-    Mesh.nodeFields['test_node_field_1'] = vertex_field
-    Mesh.nodeFields['big_node_field'] = np.random.randn(50)
-    Mesh.elemFields['test_elem_field_1'] = cell_center_field
+    Mesh.nodeFields["test_node_field_1"] = vertex_field
+    Mesh.nodeFields["big_node_field"] = np.random.randn(50)
+    Mesh.elemFields["test_elem_field_1"] = cell_center_field
     tree = MeshToCGNS(Mesh)
     return tree
 
@@ -137,17 +132,19 @@ def tree(nodes, triangles, vertex_field, cell_center_field, nodal_tags):
 def sample_with_linked_tree(tree, tmp_path):
     sample_with_linked_tree = Sample()
     sample_with_linked_tree.add_tree(tree)
-    path_linked_sample = tmp_path / 'test_dir' / "meshes/mesh_000000000.cgns"
-    sample_with_linked_tree.link_tree(path_linked_sample, sample_with_linked_tree, linked_time=0., time=1.)
+    path_linked_sample = tmp_path / "test_dir" / "meshes/mesh_000000000.cgns"
+    sample_with_linked_tree.link_tree(
+        path_linked_sample, sample_with_linked_tree, linked_time=0.0, time=1.0
+    )
     return sample_with_linked_tree
 
 
 @pytest.fixture()
 def tree3d(nodes3d, triangles, vertex_field, cell_center_field):
     Mesh = MCT.CreateMeshOfTriangles(nodes3d, triangles)
-    Mesh.nodeFields['test_node_field_1'] = vertex_field
-    Mesh.nodeFields['big_node_field'] = np.random.randn(50)
-    Mesh.elemFields['test_elem_field_1'] = cell_center_field
+    Mesh.nodeFields["test_node_field_1"] = vertex_field
+    Mesh.nodeFields["big_node_field"] = np.random.randn(50)
+    Mesh.elemFields["test_elem_field_1"] = cell_center_field
     tree = MeshToCGNS(Mesh)
     return tree
 
@@ -165,13 +162,16 @@ def sample_with_tree3d(sample, tree3d):
 
 
 @pytest.fixture()
-def sample_with_tree_and_scalar_and_time_series(sample_with_tree, ):
-    sample_with_tree.add_scalar('r', np.random.randn())
-    sample_with_tree.add_scalar('test_scalar_1', np.random.randn())
+def sample_with_tree_and_scalar_and_time_series(
+    sample_with_tree,
+):
+    sample_with_tree.add_scalar("r", np.random.randn())
+    sample_with_tree.add_scalar("test_scalar_1", np.random.randn())
     sample_with_tree.add_time_series(
-        'test_time_series_1', np.arange(
-            111, dtype=float), np.random.randn(111))
+        "test_time_series_1", np.arange(111, dtype=float), np.random.randn(111)
+    )
     return sample_with_tree
+
 
 # %% Tests
 
@@ -190,53 +190,50 @@ def current_directory():
     return os.path.dirname(os.path.abspath(__file__))
 
 
-class Test_Sample():
-
+class Test_Sample:
     # -------------------------------------------------------------------------#
     def test___init__(self, current_directory):
         dataset_path_1 = os.path.join(
-            current_directory,
-            "dataset",
-            "samples",
-            "sample_000000000")
+            current_directory, "dataset", "samples", "sample_000000000"
+        )
         dataset_path_2 = os.path.join(
-            current_directory,
-            "dataset",
-            "samples",
-            "sample_000000001")
+            current_directory, "dataset", "samples", "sample_000000001"
+        )
         dataset_path_3 = os.path.join(
-            current_directory,
-            "dataset",
-            "samples",
-            "sample_000000002")
+            current_directory, "dataset", "samples", "sample_000000002"
+        )
         sample_already_filled_1 = Sample(dataset_path_1)
         sample_already_filled_2 = Sample(dataset_path_2)
         sample_already_filled_3 = Sample(dataset_path_3)
-        assert sample_already_filled_1._meshes is not None and sample_already_filled_1._scalars is not None
-        assert sample_already_filled_2._meshes is not None and sample_already_filled_2._scalars is not None
-        assert sample_already_filled_3._meshes is not None and sample_already_filled_3._scalars is not None
+        assert (
+            sample_already_filled_1._meshes is not None
+            and sample_already_filled_1._scalars is not None
+        )
+        assert (
+            sample_already_filled_2._meshes is not None
+            and sample_already_filled_2._scalars is not None
+        )
+        assert (
+            sample_already_filled_3._meshes is not None
+            and sample_already_filled_3._scalars is not None
+        )
 
     def test__init__unknown_directory(self, current_directory):
         dataset_path = os.path.join(
-            current_directory,
-            "dataset",
-            "samples",
-            "sample_000000298")
+            current_directory, "dataset", "samples", "sample_000000298"
+        )
         with pytest.raises(FileNotFoundError):
             Sample(dataset_path)
 
     def test__init__file_provided(self, current_directory):
         dataset_path = os.path.join(
-            current_directory,
-            "dataset",
-            "samples",
-            "sample_000067392")
+            current_directory, "dataset", "samples", "sample_000067392"
+        )
         with pytest.raises(FileExistsError):
             Sample(dataset_path)
 
     # -------------------------------------------------------------------------#
-    def test_set_default_base(
-            self, sample, topological_dim, physical_dim):
+    def test_set_default_base(self, sample, topological_dim, physical_dim):
         sample.init_base(topological_dim, physical_dim, time=0.5)
 
         sample.set_default_base(f"Base_{topological_dim}_{physical_dim}", 0.5)
@@ -247,44 +244,34 @@ class Test_Sample():
         assert sample.get_time_assignment() == 0.5
         assert sample.get_base_assignment("test") == "test"
 
-        sample.set_default_base(f"Base_{topological_dim}_{physical_dim}") # already set
-        sample.set_default_base(None) # will not assign to None
+        sample.set_default_base(f"Base_{topological_dim}_{physical_dim}")  # already set
+        sample.set_default_base(None)  # will not assign to None
         assert sample.get_base_assignment() == f"Base_{topological_dim}_{physical_dim}"
         with pytest.raises(ValueError):
-            sample.set_default_base(f"Unknown base name")
+            sample.set_default_base("Unknown base name")
 
     def test_set_default_zone_with_default_base(
-            self, sample, topological_dim, physical_dim, base_name, zone_name, zone_shape):
+        self, sample, topological_dim, physical_dim, base_name, zone_name, zone_shape
+    ):
         sample.init_base(topological_dim, physical_dim, base_name, time=0.5)
         sample.set_default_base(base_name)
         # No zone provided
         assert sample.get_zone() is None
 
-        sample.init_zone(
-            zone_shape,
-            CGK.Structured_s,
-            zone_name,
-            base_name=base_name)
+        sample.init_zone(zone_shape, CGK.Structured_s, zone_name, base_name=base_name)
         # Look for the only zone in the default base
         assert sample.get_zone() is not None
 
-        sample.init_zone(
-            zone_shape,
-            CGK.Structured_s,
-            zone_name,
-            base_name=base_name)
+        sample.init_zone(zone_shape, CGK.Structured_s, zone_name, base_name=base_name)
         # There is more than one zone in this base
         with pytest.raises(KeyError):
             sample.get_zone()
 
     def test_set_default_zone(
-            self, sample, topological_dim, physical_dim, base_name, zone_name, zone_shape):
+        self, sample, topological_dim, physical_dim, base_name, zone_name, zone_shape
+    ):
         sample.init_base(topological_dim, physical_dim, base_name, time=0.5)
-        sample.init_zone(
-            zone_shape,
-            CGK.Structured_s,
-            zone_name,
-            base_name=base_name)
+        sample.init_zone(zone_shape, CGK.Structured_s, zone_name, base_name=base_name)
 
         sample.set_default_zone_base(zone_name, base_name, 0.5)
         # check dims getters
@@ -293,37 +280,36 @@ class Test_Sample():
         assert sample.get_base_assignment() == base_name
         assert sample.get_time_assignment() == 0.5
 
-        sample.set_default_base(base_name) # already set
-        sample.set_default_base(None) # will not assign to None
+        sample.set_default_base(base_name)  # already set
+        sample.set_default_base(None)  # will not assign to None
         assert sample.get_base_assignment() == base_name
         with pytest.raises(ValueError):
-            sample.set_default_base(f"Unknown base name")
+            sample.set_default_base("Unknown base name")
 
         assert sample.get_zone_assignment() == zone_name
         assert sample.get_time_assignment() == 0.5
 
         assert sample.get_zone() is not None
         sample.set_default_zone_base(zone_name, base_name)
-        sample.set_default_zone_base(None, base_name) # will not assign to None
+        sample.set_default_zone_base(None, base_name)  # will not assign to None
         assert sample.get_zone_assignment() == zone_name
         with pytest.raises(ValueError):
             sample.set_default_zone_base("Unknown zone name", base_name)
 
-    def test_set_default_time(
-            self, sample, topological_dim, physical_dim):
+    def test_set_default_time(self, sample, topological_dim, physical_dim):
         sample.init_base(topological_dim, physical_dim, time=0.5)
         sample.init_base(topological_dim, physical_dim, "OK_name", time=1.5)
-
 
         assert sample.get_time_assignment() == 0.5
         sample.set_default_time(1.5)
         assert sample.get_time_assignment() == 1.5, "here"
 
-        sample.set_default_time(1.5) # already set
-        sample.set_default_time(None) # will not assign to None
+        sample.set_default_time(1.5)  # already set
+        sample.set_default_time(None)  # will not assign to None
         assert sample.get_time_assignment() == 1.5
         with pytest.raises(ValueError):
             sample.set_default_time(2.5)
+
     # -------------------------------------------------------------------------#
 
     def test_show_tree(self, sample_with_tree_and_scalar_and_time_series):
@@ -340,21 +326,21 @@ class Test_Sample():
         sample_with_tree_and_scalar_and_time_series.get_mesh()
 
     def test_get_mesh_without_links(self, sample_with_linked_tree):
-        sample_with_linked_tree.get_mesh(time=1.,apply_links=False)
+        sample_with_linked_tree.get_mesh(time=1.0, apply_links=False)
 
     def test_get_mesh_with_links_in_memory(self, sample_with_linked_tree):
-        sample_with_linked_tree.get_mesh(time=1.,apply_links=True, in_memory=True)
+        sample_with_linked_tree.get_mesh(time=1.0, apply_links=True, in_memory=True)
 
     def test_get_mesh_with_links(self, sample_with_linked_tree, tmp_path):
-        sample_with_linked_tree.save(tmp_path / 'test_dir')
-        sample_with_linked_tree.get_mesh(time=1.,apply_links=True)
+        sample_with_linked_tree.save(tmp_path / "test_dir")
+        sample_with_linked_tree.get_mesh(time=1.0, apply_links=True)
 
     def test_set_meshes_empty(self, sample, tree):
-        sample.set_meshes({0.:tree})
+        sample.set_meshes({0.0: tree})
 
     def test_set_meshes(self, sample_with_tree, tree):
         with pytest.raises(KeyError):
-            sample_with_tree.set_meshes({0.:tree})
+            sample_with_tree.set_meshes({0.0: tree})
 
     def test_add_tree_empty(self, sample_with_tree):
         with pytest.raises(ValueError):
@@ -369,17 +355,24 @@ class Test_Sample():
         sample.add_tree(tree, time=0.2)
 
         assert isinstance(sample.del_tree(0.2), list)
-        assert list(sample._meshes.keys()) == [0.]
-        assert list(sample._links.keys()) == [0.]
-        assert list(sample._paths.keys()) == [0.]
+        assert list(sample._meshes.keys()) == [0.0]
+        assert list(sample._links.keys()) == [0.0]
+        assert list(sample._paths.keys()) == [0.0]
 
-        assert isinstance(sample.del_tree(0.), list)
+        assert isinstance(sample.del_tree(0.0), list)
         assert list(sample._meshes.keys()) == []
         assert list(sample._links.keys()) == []
         assert list(sample._paths.keys()) == []
 
     def test_link_tree(self, sample_with_linked_tree):
-        link_checks = ['/Base_2_2/Zone/Elements_Selections', '/Base_2_2/Zone/Points_Selections', '/Base_2_2/Zone/Points_Selections/tag', '/Base_2_2/Zone/Elements_TRI_3', '/Base_2_2/Zone/GridCoordinates', '/Base_2_2/Zone/ZoneBC']
+        link_checks = [
+            "/Base_2_2/Zone/Elements_Selections",
+            "/Base_2_2/Zone/Points_Selections",
+            "/Base_2_2/Zone/Points_Selections/tag",
+            "/Base_2_2/Zone/Elements_TRI_3",
+            "/Base_2_2/Zone/GridCoordinates",
+            "/Base_2_2/Zone/ZoneBC",
+        ]
         for link in sample_with_linked_tree._links[1]:
             assert link[1] == "mesh_000000000.cgns"
             assert link[2] == link[3]
@@ -387,7 +380,7 @@ class Test_Sample():
 
     def test_on_error_del_tree(self, sample, tree):
         with pytest.raises(KeyError):
-            sample.del_tree(0.)
+            sample.del_tree(0.0)
 
         sample.add_tree(tree)
         sample.add_tree(tree, time=0.2)
@@ -401,13 +394,15 @@ class Test_Sample():
         assert sample.get_topological_dim(base_name) == topological_dim
         assert sample.get_physical_dim(base_name) == physical_dim
 
-    def test_del_base_existing_base(self, sample, base_name, topological_dim, physical_dim):
-        second_base_name = base_name + '_2'
+    def test_del_base_existing_base(
+        self, sample, base_name, topological_dim, physical_dim
+    ):
+        second_base_name = base_name + "_2"
         sample.init_base(topological_dim, physical_dim, base_name)
         sample.init_base(topological_dim, physical_dim, second_base_name)
 
         # Delete first base
-        updated_cgns_tree = sample.del_base(base_name, 0.)
+        updated_cgns_tree = sample.del_base(base_name, 0.0)
         assert updated_cgns_tree is not None and isinstance(updated_cgns_tree, list)
 
         # Testing the resulting tree
@@ -434,7 +429,7 @@ class Test_Sample():
         assert new_sample.get_base_names() == [base_name]
 
         # Deleting the last base at time 0.0
-        updated_cgns_tree = sample.del_base(second_base_name, 0.)
+        updated_cgns_tree = sample.del_base(second_base_name, 0.0)
         assert sample.get_base(second_base_name) is None
         assert updated_cgns_tree is not None and isinstance(updated_cgns_tree, list)
 
@@ -443,24 +438,31 @@ class Test_Sample():
         assert sample.get_base(base_name) is None
         assert updated_cgns_tree is not None and isinstance(updated_cgns_tree, list)
 
-    def test_del_base_nonexistent_base_nonexistent_time(self, sample, base_name, topological_dim, physical_dim):
+    def test_del_base_nonexistent_base_nonexistent_time(
+        self, sample, base_name, topological_dim, physical_dim
+    ):
         sample.init_base(topological_dim, physical_dim, base_name, time=1.0)
         with pytest.raises(KeyError):
             sample.del_base(base_name, time=2.0)
         with pytest.raises(KeyError):
-            sample.del_base('unknown', time=1.0)
+            sample.del_base("unknown", time=1.0)
 
     def test_del_base_no_cgns_tree(self, sample):
         with pytest.raises(KeyError):
-            sample.del_base('unknwon', 0.0)
+            sample.del_base("unknwon", 0.0)
 
-    def test_init_base_no_base_name(
-            self, sample, topological_dim, physical_dim):
+    def test_init_base_no_base_name(self, sample, topological_dim, physical_dim):
         sample.init_base(topological_dim, physical_dim)
 
         # check dims getters
-        assert sample.get_topological_dim(f"Base_{topological_dim}_{physical_dim}") == topological_dim
-        assert sample.get_physical_dim(f"Base_{topological_dim}_{physical_dim}") == physical_dim
+        assert (
+            sample.get_topological_dim(f"Base_{topological_dim}_{physical_dim}")
+            == topological_dim
+        )
+        assert (
+            sample.get_physical_dim(f"Base_{topological_dim}_{physical_dim}")
+            == physical_dim
+        )
 
         # check setting default base
         sample.set_default_base(f"Base_{topological_dim}_{physical_dim}")
@@ -468,52 +470,40 @@ class Test_Sample():
         assert sample.get_physical_dim() == physical_dim
 
     def test_get_base_names(self, sample):
-        assert (sample.get_base_names() == [])
-        sample.init_base(3, 3, 'base_name_1')
-        sample.init_base(3, 3, 'base_name_2')
-        assert (sample.get_base_names() == ['base_name_1', 'base_name_2'])
-        assert (
-            sample.get_base_names(
-                full_path=True) == [
-                '/base_name_1',
-                '/base_name_2'])
+        assert sample.get_base_names() == []
+        sample.init_base(3, 3, "base_name_1")
+        sample.init_base(3, 3, "base_name_2")
+        assert sample.get_base_names() == ["base_name_1", "base_name_2"]
+        assert sample.get_base_names(full_path=True) == ["/base_name_1", "/base_name_2"]
         # check dims getters
-        assert sample.get_topological_dim('base_name_1') == 3
-        assert sample.get_physical_dim('base_name_1') == 3
-        assert sample.get_topological_dim('base_name_2') == 3
-        assert sample.get_physical_dim('base_name_2') == 3
+        assert sample.get_topological_dim("base_name_1") == 3
+        assert sample.get_physical_dim("base_name_1") == 3
+        assert sample.get_topological_dim("base_name_2") == 3
+        assert sample.get_physical_dim("base_name_2") == 3
 
     def test_get_base(self, sample, base_name):
         sample.init_tree()
-        assert (sample.get_base() is None)
+        assert sample.get_base() is None
         sample.init_base(3, 3, base_name)
-        assert (sample.get_base(base_name) is not None)
-        assert (sample.get_base() is not None)
-        sample.init_base(3, 3, 'other_base_name')
-        assert (sample.get_base(base_name) is not None)
+        assert sample.get_base(base_name) is not None
+        assert sample.get_base() is not None
+        sample.init_base(3, 3, "other_base_name")
+        assert sample.get_base(base_name) is not None
         with pytest.raises(KeyError):
             sample.get_base()
         # check dims getters
         assert sample.get_topological_dim(base_name) == 3
         assert sample.get_physical_dim(base_name) == 3
-        assert sample.get_topological_dim('other_base_name') == 3
-        assert sample.get_physical_dim('other_base_name') == 3
+        assert sample.get_topological_dim("other_base_name") == 3
+        assert sample.get_physical_dim("other_base_name") == 3
 
     # -------------------------------------------------------------------------#
     def test_init_zone(self, sample, base_name, zone_name, zone_shape):
         with pytest.raises(KeyError):
             sample.init_zone(zone_shape, zone_name=zone_name, base_name=base_name)
         sample.init_base(3, 3, base_name)
-        sample.init_zone(
-            zone_shape,
-            CGK.Structured_s,
-            zone_name,
-            base_name=base_name)
-        sample.init_zone(
-            zone_shape,
-            CGK.Unstructured_s,
-            zone_name,
-            base_name=base_name)
+        sample.init_zone(zone_shape, CGK.Structured_s, zone_name, base_name=base_name)
+        sample.init_zone(zone_shape, CGK.Unstructured_s, zone_name, base_name=base_name)
         # check dims getters
         assert sample.get_topological_dim(base_name) == 3
         assert sample.get_physical_dim(base_name) == 3
@@ -526,20 +516,14 @@ class Test_Sample():
         topological_dim, physical_dim = 3, 3
         sample.init_base(topological_dim, physical_dim, base_name)
 
-        second_zone_name = zone_name + '_2'
+        second_zone_name = zone_name + "_2"
+        sample.init_zone(zone_shape, CGK.Structured_s, zone_name, base_name=base_name)
         sample.init_zone(
-            zone_shape,
-            CGK.Structured_s,
-            zone_name,
-            base_name=base_name)
-        sample.init_zone(
-            zone_shape,
-            CGK.Unstructured_s,
-            second_zone_name,
-            base_name=base_name)
+            zone_shape, CGK.Unstructured_s, second_zone_name, base_name=base_name
+        )
 
         # Delete first zone
-        updated_cgns_tree = sample.del_zone(zone_name, base_name, 0.)
+        updated_cgns_tree = sample.del_zone(zone_name, base_name, 0.0)
         assert updated_cgns_tree is not None and isinstance(updated_cgns_tree, list)
 
         # Testing the resulting tree
@@ -550,17 +534,11 @@ class Test_Sample():
         # Add 2 zones and delete one zone at time 0.2
         sample.init_base(topological_dim, physical_dim, base_name, 0.2)
         sample.init_zone(
-            zone_shape,
-            CGK.Structured_s,
-            zone_name,
-            base_name=base_name,
-            time=0.2)
+            zone_shape, CGK.Structured_s, zone_name, base_name=base_name, time=0.2
+        )
         sample.init_zone(
-            zone_shape,
-            CGK.Unstructured_s,
-            "test",
-            base_name=base_name,
-            time=0.2)
+            zone_shape, CGK.Unstructured_s, "test", base_name=base_name, time=0.2
+        )
 
         updated_cgns_tree = sample.del_zone("test", base_name, 0.2)
         assert sample.get_zone("tree", base_name, 0.2) is None
@@ -574,7 +552,7 @@ class Test_Sample():
         assert new_sample.get_zone_names(base_name) == [zone_name]
 
         # Deleting the last zone at time 0.0
-        updated_cgns_tree = sample.del_zone(second_zone_name, base_name, 0.)
+        updated_cgns_tree = sample.del_zone(second_zone_name, base_name, 0.0)
         assert sample.get_zone(second_zone_name, base_name) is None
         assert updated_cgns_tree is not None and isinstance(updated_cgns_tree, list)
 
@@ -583,60 +561,52 @@ class Test_Sample():
         assert sample.get_zone(zone_name, base_name) is None
         assert updated_cgns_tree is not None and isinstance(updated_cgns_tree, list)
 
-    def test_del_zone_nonexistent_zone_nonexistent_time(self, sample, base_name, zone_shape, topological_dim, physical_dim):
+    def test_del_zone_nonexistent_zone_nonexistent_time(
+        self, sample, base_name, zone_shape, topological_dim, physical_dim
+    ):
         sample.init_base(topological_dim, physical_dim, base_name, time=1.0)
         zone_name = "test123"
         sample.init_zone(
-            zone_shape,
-            CGK.Structured_s,
-            zone_name,
-            base_name=base_name,
-            time=1.0)
+            zone_shape, CGK.Structured_s, zone_name, base_name=base_name, time=1.0
+        )
         with pytest.raises(KeyError):
             sample.del_zone(zone_name, base_name, 2.0)
         with pytest.raises(KeyError):
-            sample.del_zone('unknown', base_name, 1.0)
+            sample.del_zone("unknown", base_name, 1.0)
 
     def test_del_zone_no_cgns_tree(self, sample):
         sample.init_base(2, 3, "only_base")
         with pytest.raises(KeyError):
-            sample.del_zone('unknwon', "only_base", 0.0)
+            sample.del_zone("unknwon", "only_base", 0.0)
 
     def test_has_zone(self, sample, base_name, zone_name):
         sample.init_base(3, 3, base_name)
         sample.init_zone(
-            np.random.randint(0, 10, size=3),
-            zone_name=zone_name,
-            base_name=base_name)
+            np.random.randint(0, 10, size=3), zone_name=zone_name, base_name=base_name
+        )
         sample.show_tree()
-        assert (sample.has_zone(zone_name, base_name))
-        assert (not sample.has_zone('not_present_zone_name', base_name))
-        assert (not sample.has_zone(zone_name, 'not_present_base_name'))
-        assert (
-            not sample.has_zone(
-                'not_present_zone_name',
-                'not_present_base_name'))
+        assert sample.has_zone(zone_name, base_name)
+        assert not sample.has_zone("not_present_zone_name", base_name)
+        assert not sample.has_zone(zone_name, "not_present_base_name")
+        assert not sample.has_zone("not_present_zone_name", "not_present_base_name")
 
     def test_get_zone_names(self, sample, base_name):
         sample.init_base(3, 3, base_name)
         sample.init_zone(
             np.random.randint(0, 10, size=3),
-            zone_name='zone_name_1',
-            base_name=base_name)
+            zone_name="zone_name_1",
+            base_name=base_name,
+        )
         sample.init_zone(
             np.random.randint(0, 10, size=3),
-            zone_name='zone_name_2',
-            base_name=base_name)
-        assert (
-            sample.get_zone_names(base_name) == [
-                'zone_name_1',
-                'zone_name_2'])
-        assert (
-            sample.get_zone_names(
-                base_name,
-                full_path=True) == [
-                f'{base_name}/zone_name_1',
-                f'{base_name}/zone_name_2'])
+            zone_name="zone_name_2",
+            base_name=base_name,
+        )
+        assert sample.get_zone_names(base_name) == ["zone_name_1", "zone_name_2"]
+        assert sample.get_zone_names(base_name, full_path=True) == [
+            f"{base_name}/zone_name_1",
+            f"{base_name}/zone_name_2",
+        ]
 
     def test_get_zone_type(self, sample, zone_name, base_name):
         with pytest.raises(KeyError):
@@ -648,48 +618,44 @@ class Test_Sample():
         with pytest.raises(KeyError):
             sample.get_zone_type(zone_name, base_name)
         sample.init_zone(
-            np.random.randint(0, 10, size=3),
-            zone_name=zone_name,
-            base_name=base_name)
-        assert (
-            sample.get_zone_type(
-                zone_name,
-                base_name) == CGK.Unstructured_s)
+            np.random.randint(0, 10, size=3), zone_name=zone_name, base_name=base_name
+        )
+        assert sample.get_zone_type(zone_name, base_name) == CGK.Unstructured_s
 
     def test_get_zone(self, sample, zone_name, base_name):
-        assert (sample.get_zone(zone_name, base_name) is None)
+        assert sample.get_zone(zone_name, base_name) is None
         sample.init_base(3, 3, base_name)
-        assert (sample.get_zone(zone_name, base_name) is None)
+        assert sample.get_zone(zone_name, base_name) is None
+        sample.init_zone(
+            np.random.randint(0, 10, size=3), zone_name=zone_name, base_name=base_name
+        )
+        assert sample.get_zone() is not None
+        assert sample.get_zone(zone_name, base_name) is not None
         sample.init_zone(
             np.random.randint(0, 10, size=3),
-            zone_name=zone_name,
-            base_name=base_name)
-        assert (sample.get_zone() is not None)
-        assert (sample.get_zone(zone_name, base_name) is not None)
-        sample.init_zone(
-            np.random.randint(0, 10, size=3),
-            zone_name='other_zone_name',
-            base_name=base_name)
-        assert (sample.get_zone(zone_name, base_name) is not None)
+            zone_name="other_zone_name",
+            base_name=base_name,
+        )
+        assert sample.get_zone(zone_name, base_name) is not None
         with pytest.raises(KeyError):
-            assert (sample.get_zone() is not None)
+            assert sample.get_zone() is not None
 
     # -------------------------------------------------------------------------#
     def test_get_scalar_names(self, sample):
-        assert (sample.get_scalar_names() == [])
+        assert sample.get_scalar_names() == []
 
     def test_get_scalar_empty(self, sample):
-        assert (sample.get_scalar('missing_scalar_name') is None)
+        assert sample.get_scalar("missing_scalar_name") is None
 
     def test_get_scalar(self, sample_with_scalar):
-        assert (sample_with_scalar.get_scalar('missing_scalar_name') is None)
-        assert (sample_with_scalar.get_scalar('test_scalar_1') is not None)
+        assert sample_with_scalar.get_scalar("missing_scalar_name") is None
+        assert sample_with_scalar.get_scalar("test_scalar_1") is not None
 
     def test_add_scalar_empty(self, sample_with_scalar):
-        assert isinstance(sample_with_scalar.get_scalar('test_scalar_1'), float)
+        assert isinstance(sample_with_scalar.get_scalar("test_scalar_1"), float)
 
     def test_add_scalar(self, sample_with_scalar):
-        sample_with_scalar.add_scalar('test_scalar_2', np.random.randn())
+        sample_with_scalar.add_scalar("test_scalar_2", np.random.randn())
 
     def test_del_scalar_unknown_scalar(self, sample_with_scalar):
         with pytest.raises(KeyError):
@@ -703,42 +669,42 @@ class Test_Sample():
     def test_del_scalar(self, sample_with_scalar):
         assert len(sample_with_scalar.get_scalar_names()) == 1
 
-        sample_with_scalar.add_scalar('test_scalar_2', np.random.randn(5))
+        sample_with_scalar.add_scalar("test_scalar_2", np.random.randn(5))
         assert len(sample_with_scalar.get_scalar_names()) == 2
 
-        scalar = sample_with_scalar.del_scalar('test_scalar_1')
+        scalar = sample_with_scalar.del_scalar("test_scalar_1")
         assert len(sample_with_scalar.get_scalar_names()) == 1
         assert scalar is not None
         assert isinstance(scalar, float)
 
-        scalar = sample_with_scalar.del_scalar('test_scalar_2')
+        scalar = sample_with_scalar.del_scalar("test_scalar_2")
         assert len(sample_with_scalar.get_scalar_names()) == 0
         assert scalar is not None
         assert isinstance(scalar, np.ndarray)
+
     # -------------------------------------------------------------------------#
     def test_get_time_series_names_empty(self, sample):
-        assert (sample.get_time_series_names() == [])
+        assert sample.get_time_series_names() == []
 
     def test_get_time_series_names(self, sample_with_time_series):
-        assert (sample_with_time_series.get_time_series_names()
-                == ['test_time_series_1'])
+        assert sample_with_time_series.get_time_series_names() == ["test_time_series_1"]
 
     def test_get_time_series_empty(self, sample):
-        assert (sample.get_time_series('missing_time_series_name') is None)
+        assert sample.get_time_series("missing_time_series_name") is None
 
     def test_get_time_series(self, sample_with_time_series):
-        assert (sample_with_time_series.get_time_series(
-            'missing_time_series_name') is None)
-        assert (sample_with_time_series.get_time_series(
-            'test_time_series_1') is not None)
+        assert (
+            sample_with_time_series.get_time_series("missing_time_series_name") is None
+        )
+        assert sample_with_time_series.get_time_series("test_time_series_1") is not None
 
     def test_add_time_series_empty(self, sample_with_time_series):
         pass
 
     def test_add_time_series(self, sample_with_time_series):
         sample_with_time_series.add_time_series(
-            'test_time_series_2', np.arange(
-                111, dtype=float), np.random.randn(111))
+            "test_time_series_2", np.arange(111, dtype=float), np.random.randn(111)
+        )
 
     def test_del_time_series_unknown_scalar(self, sample_with_time_series):
         with pytest.raises(KeyError):
@@ -753,21 +719,18 @@ class Test_Sample():
         assert len(sample_with_time_series.get_time_series_names()) == 1
 
         sample_with_time_series.add_time_series(
-            'test_time_series_2',
-            np.arange(
-                222,
-                dtype=float),
-            np.random.randn(222))
+            "test_time_series_2", np.arange(222, dtype=float), np.random.randn(222)
+        )
         assert len(sample_with_time_series.get_time_series_names()) == 2
 
-        time_series = sample_with_time_series.del_time_series('test_time_series_1')
+        time_series = sample_with_time_series.del_time_series("test_time_series_1")
         assert len(sample_with_time_series.get_time_series_names()) == 1
         assert time_series is not None
         assert isinstance(time_series, tuple)
         assert isinstance(time_series[0], np.ndarray)
         assert isinstance(time_series[1], np.ndarray)
 
-        time_series = sample_with_time_series.del_time_series('test_time_series_2')
+        time_series = sample_with_time_series.del_time_series("test_time_series_2")
         assert len(sample_with_time_series.get_time_series_names()) == 0
         assert time_series is not None
         assert isinstance(time_series, tuple)
@@ -776,252 +739,221 @@ class Test_Sample():
 
     # -------------------------------------------------------------------------#
     def test_get_nodal_tags_empty(self, sample):
-        assert (sample.get_nodal_tags() == {})
+        assert sample.get_nodal_tags() == {}
 
     def test_get_nodal_tags(self, sample_with_tree, nodal_tags):
-        assert (np.all(sample_with_tree.get_nodal_tags()["tag"] == nodal_tags))
+        assert np.all(sample_with_tree.get_nodal_tags()["tag"] == nodal_tags)
 
     # -------------------------------------------------------------------------#
     def test_get_nodes_empty(self, sample):
-        assert (sample.get_nodes() is None)
+        assert sample.get_nodes() is None
 
     def test_get_nodes(self, sample_with_tree, nodes):
-        assert (np.all(sample_with_tree.get_nodes() == nodes))
+        assert np.all(sample_with_tree.get_nodes() == nodes)
 
     def test_get_nodes3d(self, sample_with_tree3d, nodes3d):
-        assert (np.all(sample_with_tree3d.get_nodes() == nodes3d))
+        assert np.all(sample_with_tree3d.get_nodes() == nodes3d)
 
     def test_set_nodes(self, sample, nodes, zone_name, base_name):
         sample.init_base(3, 3, base_name)
         with pytest.raises(KeyError):
             sample.set_nodes(nodes, zone_name, base_name)
         sample.init_zone(
-            np.array([len(nodes), 0, 0]),
-            zone_name=zone_name,
-            base_name=base_name)
+            np.array([len(nodes), 0, 0]), zone_name=zone_name, base_name=base_name
+        )
         sample.set_nodes(nodes, zone_name, base_name)
 
     # -------------------------------------------------------------------------#
     def test_get_elements_empty(self, sample):
-        assert (sample.get_elements() == {})
+        assert sample.get_elements() == {}
 
     def test_get_elements(self, sample_with_tree, triangles):
-        assert (list(sample_with_tree.get_elements().keys()) == ['TRI_3'])
+        assert list(sample_with_tree.get_elements().keys()) == ["TRI_3"]
         print(f"{triangles=}")
         print(f"{sample_with_tree.get_elements()=}")
-        assert (np.all(sample_with_tree.get_elements()['TRI_3'] == triangles))
+        assert np.all(sample_with_tree.get_elements()["TRI_3"] == triangles)
 
     # -------------------------------------------------------------------------#
     def test_get_field_names(self, sample):
-        assert (sample.get_field_names() == [])
-        assert (sample.get_field_names(location='CellCenter') == [])
+        assert sample.get_field_names() == []
+        assert sample.get_field_names(location="CellCenter") == []
 
     def test_get_field_empty(self, sample):
-        assert (sample.get_field('missing_field_name') is None)
-        assert (
-            sample.get_field(
-                'missing_field_name',
-                location='CellCenter') is None)
+        assert sample.get_field("missing_field_name") is None
+        assert sample.get_field("missing_field_name", location="CellCenter") is None
 
     def test_get_field(self, sample_with_tree):
-        assert (sample_with_tree.get_field('missing_field') is None)
-        assert (sample_with_tree.get_field('test_node_field_1').shape == (5,))
-        assert (
-            sample_with_tree.get_field(
-                'test_elem_field_1',
-                location='CellCenter').shape == (
-                3,
-            ))
+        assert sample_with_tree.get_field("missing_field") is None
+        assert sample_with_tree.get_field("test_node_field_1").shape == (5,)
+        assert sample_with_tree.get_field(
+            "test_elem_field_1", location="CellCenter"
+        ).shape == (3,)
 
-    def test_add_field_vertex(
-            self, sample, vertex_field, zone_name, base_name):
+    def test_add_field_vertex(self, sample, vertex_field, zone_name, base_name):
         sample.init_base(3, 3, base_name)
         with pytest.raises(KeyError):
-            sample.add_field(
-                'test_node_field_2',
-                vertex_field,
-                zone_name,
-                base_name)
+            sample.add_field("test_node_field_2", vertex_field, zone_name, base_name)
         sample.init_zone(
-            np.random.randint(0, 10, size=3),
-            zone_name=zone_name,
-            base_name=base_name)
-        sample.add_field(
-            'test_node_field_2',
-            vertex_field,
-            zone_name,
-            base_name)
+            np.random.randint(0, 10, size=3), zone_name=zone_name, base_name=base_name
+        )
+        sample.add_field("test_node_field_2", vertex_field, zone_name, base_name)
 
     def test_add_field_cell_center(
-            self, sample, cell_center_field, zone_name, base_name):
+        self, sample, cell_center_field, zone_name, base_name
+    ):
         sample.init_base(3, 3, base_name)
         with pytest.raises(KeyError):
             sample.add_field(
-                'test_elem_field_2',
+                "test_elem_field_2",
                 cell_center_field,
                 zone_name,
                 base_name,
-                location='CellCenter')
+                location="CellCenter",
+            )
         sample.init_zone(
-            np.random.randint(0, 10, size=3),
-            zone_name=zone_name,
-            base_name=base_name)
+            np.random.randint(0, 10, size=3), zone_name=zone_name, base_name=base_name
+        )
         sample.add_field(
-            'test_elem_field_2',
+            "test_elem_field_2",
             cell_center_field,
             zone_name,
             base_name,
-            location='CellCenter')
+            location="CellCenter",
+        )
 
-    def test_add_field_vertex_already_present(
-            self, sample_with_tree, vertex_field):
+    def test_add_field_vertex_already_present(self, sample_with_tree, vertex_field):
         # with pytest.raises(KeyError):
         sample_with_tree.show_tree()
         sample_with_tree.add_field(
-            'test_node_field_1',
-            vertex_field,
-            'Zone',
-            'Base_2_2')
+            "test_node_field_1", vertex_field, "Zone", "Base_2_2"
+        )
 
     def test_add_field_cell_center_already_present(
-            self, sample_with_tree, cell_center_field):
+        self, sample_with_tree, cell_center_field
+    ):
         # with pytest.raises(KeyError):
         sample_with_tree.show_tree()
         sample_with_tree.add_field(
-            'test_elem_field_1',
+            "test_elem_field_1",
             cell_center_field,
-            'Zone',
-            'Base_2_2',
-            location='CellCenter')
+            "Zone",
+            "Base_2_2",
+            location="CellCenter",
+        )
 
     def test_del_field_existing(self, sample_with_tree):
         with pytest.raises(KeyError):
             sample_with_tree.del_field(
-                'unknown',
-                'Zone',
-                'Base_2_2',
-                location='CellCenter')
+                "unknown", "Zone", "Base_2_2", location="CellCenter"
+            )
         with pytest.raises(KeyError):
             sample_with_tree.del_field(
-                'unknown',
-                'unknown_zone',
-                'Base_2_2',
-                location='CellCenter')
+                "unknown", "unknown_zone", "Base_2_2", location="CellCenter"
+            )
 
     def test_del_field_nonexistent(self, base_name):
         sample = Sample()
         sample.init_base(2, 2, base_name)
         with pytest.raises(KeyError):
             sample.del_field(
-                'unknown',
-                'unknown_zone',
-                base_name,
-                location='CellCenter')
+                "unknown", "unknown_zone", base_name, location="CellCenter"
+            )
 
-    def test_del_field_in_zone(
-            self, zone_name, base_name, cell_center_field):
+    def test_del_field_in_zone(self, zone_name, base_name, cell_center_field):
         sample = Sample()
         sample.init_base(3, 3, base_name)
         sample.init_zone(
-            np.random.randint(0, 10, size=3),
-            zone_name=zone_name,
-            base_name=base_name)
+            np.random.randint(0, 10, size=3), zone_name=zone_name, base_name=base_name
+        )
         sample.add_field(
-            'test_elem_field_1',
+            "test_elem_field_1",
             cell_center_field,
             zone_name,
             base_name,
-            location='CellCenter')
+            location="CellCenter",
+        )
 
         # Add field 'test_elem_field_2'
         sample.add_field(
-            'test_elem_field_2',
+            "test_elem_field_2",
             cell_center_field,
             zone_name,
             base_name,
-            location='CellCenter')
-        assert isinstance(sample.get_field(
-                'test_elem_field_2',
-                zone_name,
-                base_name,
-                location='CellCenter'), np.ndarray)
+            location="CellCenter",
+        )
+        assert isinstance(
+            sample.get_field(
+                "test_elem_field_2", zone_name, base_name, location="CellCenter"
+            ),
+            np.ndarray,
+        )
 
         # Del field 'test_elem_field_2'
         new_tree = sample.del_field(
-                'test_elem_field_2',
-                zone_name,
-                base_name,
-                location='CellCenter')
+            "test_elem_field_2", zone_name, base_name, location="CellCenter"
+        )
 
         # Testing new tree on field 'test_elem_field_2'
         new_sample = Sample()
         new_sample.add_tree(new_tree)
 
-        assert new_sample.get_field(
-                'test_elem_field_2',
-                zone_name,
-                base_name,
-                location='CellCenter') is None
-        fields = new_sample.get_field_names(
-                zone_name,
-                base_name,
-                location='CellCenter'
+        assert (
+            new_sample.get_field(
+                "test_elem_field_2", zone_name, base_name, location="CellCenter"
+            )
+            is None
         )
+        fields = new_sample.get_field_names(zone_name, base_name, location="CellCenter")
 
-        assert 'test_elem_field_2' not in fields
-        assert 'test_elem_field_1' in fields
+        assert "test_elem_field_2" not in fields
+        assert "test_elem_field_1" in fields
 
         # Del field 'test_elem_field_1'
         new_tree = sample.del_field(
-            'test_elem_field_1',
-            zone_name,
-            base_name,
-            location='CellCenter')
+            "test_elem_field_1", zone_name, base_name, location="CellCenter"
+        )
 
         # Testing new tree on field 'test_elem_field_1'
         new_sample = Sample()
         new_sample.add_tree(new_tree)
 
-        assert new_sample.get_field(
-                'test_elem_field_1',
-                zone_name,
-                base_name,
-                location='CellCenter') is None
-        fields = new_sample.get_field_names(
-                zone_name,
-                base_name,
-                location='CellCenter'
+        assert (
+            new_sample.get_field(
+                "test_elem_field_1", zone_name, base_name, location="CellCenter"
+            )
+            is None
         )
+        fields = new_sample.get_field_names(zone_name, base_name, location="CellCenter")
         assert len(fields) == 0
 
     # -------------------------------------------------------------------------#
     def test_save(self, sample_with_tree_and_scalar_and_time_series, tmp_path):
-        save_dir = tmp_path / 'test_dir'
+        save_dir = tmp_path / "test_dir"
         sample_with_tree_and_scalar_and_time_series.save(save_dir)
-        assert (save_dir.is_dir())
+        assert save_dir.is_dir()
         with pytest.raises(ValueError):
             sample_with_tree_and_scalar_and_time_series.save(save_dir)
 
     def test_load_from_saved_file(
-            self, sample_with_tree_and_scalar_and_time_series, tmp_path):
-        save_dir = tmp_path / 'test_dir'
+        self, sample_with_tree_and_scalar_and_time_series, tmp_path
+    ):
+        save_dir = tmp_path / "test_dir"
         sample_with_tree_and_scalar_and_time_series.save(save_dir)
         new_sample = Sample()
         new_sample.load(save_dir)
-        assert (
-            CGU.checkSameTree(
-                sample_with_tree_and_scalar_and_time_series.get_mesh(),
-                new_sample.get_mesh()))
+        assert CGU.checkSameTree(
+            sample_with_tree_and_scalar_and_time_series.get_mesh(),
+            new_sample.get_mesh(),
+        )
 
-    def test_load_from_dir(
-            self, sample_with_tree_and_scalar_and_time_series, tmp_path):
-        save_dir = tmp_path / 'test_dir'
+    def test_load_from_dir(self, sample_with_tree_and_scalar_and_time_series, tmp_path):
+        save_dir = tmp_path / "test_dir"
         sample_with_tree_and_scalar_and_time_series.save(save_dir)
         new_sample = Sample.load_from_dir(save_dir)
-        assert (
-            CGU.checkSameTree(
-                sample_with_tree_and_scalar_and_time_series.get_mesh(),
-                new_sample.get_mesh()))
+        assert CGU.checkSameTree(
+            sample_with_tree_and_scalar_and_time_series.get_mesh(),
+            new_sample.get_mesh(),
+        )
 
     # -------------------------------------------------------------------------#
     def test___repr___empty(self, sample):
@@ -1034,5 +966,6 @@ class Test_Sample():
         print(sample_with_tree)
 
     def test___repr__with_tree_and_scalar(
-            self, sample_with_tree_and_scalar_and_time_series):
+        self, sample_with_tree_and_scalar_and_time_series
+    ):
         print(sample_with_tree_and_scalar_and_time_series)

--- a/tests/utils/test_stats.py
+++ b/tests/utils/test_stats.py
@@ -12,9 +12,6 @@ import pytest
 
 from plaid.utils.stats import OnlineStatistics, Stats
 
-from ..containers.test_dataset import nb_samples, samples
-from ..containers.test_sample import base_name, zone_name
-
 # %% Fixtures
 
 
@@ -35,7 +32,8 @@ def stats():
 
 # %% Tests
 
-class Test_OnlineStatistics():
+
+class Test_OnlineStatistics:
     def test__init__(self, online_stats):
         pass
 
@@ -51,7 +49,7 @@ class Test_OnlineStatistics():
         online_stats.get_stats()
 
 
-class Test_Stats():
+class Test_Stats:
     def test__init__(self, stats):
         pass
 


### PR DESCRIPTION
Adds a conftest in order to define common fixtures and tools for pytest. This avoids importing fixtures from one test file into another, and could be used later to define functional tests