### PR TITLE
🚀 Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/checksum_release.yml
+++ b/.github/workflows/checksum_release.yml
@@ -5,6 +5,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   get-sha256:
     runs-on: ubuntu-latest

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: '0 0 * * *'  # Every day at 00:00 UTC
 
+permissions:
+  contents: read
+
 jobs:
   doc:
     runs-on: ubuntu-latest

--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -1,4 +1,8 @@
 name: Draft JOSS PDF
+
+permissions:
+  contents: read
+
 on:
   push:
     paths:

--- a/.github/workflows/lint-format-check.yaml
+++ b/.github/workflows/lint-format-check.yaml
@@ -1,5 +1,8 @@
 name: Lint, format and type check
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -1,5 +1,9 @@
 name: PR Title Checker
 
+permissions:
+  contents: read
+  pull-requests: read
+
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -57,6 +57,8 @@ jobs:
     name: Build wheels for multiple Python versions
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   test:
     name: test
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -56,9 +58,9 @@ jobs:
   build:
     name: Build wheels for multiple Python versions
     needs: test
-    runs-on: ubuntu-latest
     permissions:
       contents: read
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,5 +1,8 @@
 name: Tests and Examples
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/PLAID-lib/plaid/security/code-scanning/8](https://github.com/PLAID-lib/plaid/security/code-scanning/8)

To fix the issue, we need to add a `permissions` block to the `build` job. The `build` job only requires read access to repository contents, so we will set `contents: read` as the minimal permissions required. This ensures the job does not inherit unnecessary write permissions from the repository.

The changes will be made in the `.github/workflows/publish-pypi.yml` file, specifically within the `build` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
