### PR TITLE
🎉 add 'summarize_cgns_tree'

### DIFF
--- a/docs/source/notebooks/sample.ipynb
+++ b/docs/source/notebooks/sample.ipynb
@@ -102,10 +102,23 @@
     "Mesh = MCT.CreateMeshOfTriangles(points, triangles)\n",
     "Mesh.nodeFields[\"test_node_field_1\"] = np.random.randn(5)\n",
     "Mesh.elemFields[\"test_elem_field_1\"] = np.random.randn(3)\n",
-    "tree = MeshToCGNS(Mesh)\n",
+    "tree = MeshToCGNS(Mesh)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"#---# Show CGNS Tree\")\n",
+    "CGH.show_cgns_tree(tree)\n",
     "\n",
-    "# Display CGNS Tree\n",
-    "CGH.show_cgns_tree(tree)\n"
+    "print(\"\\n#---# Summarize CGNS Tree\")\n",
+    "CGH.summarize_cgns_tree(tree)\n",
+    "\n",
+    "print(\"\\n#---# Summarize CGNS Tree without additional Field Information\")\n",
+    "CGH.summarize_cgns_tree(tree, verbose=False)"
    ]
   },
   {

--- a/examples/containers/sample_example.py
+++ b/examples/containers/sample_example.py
@@ -71,6 +71,10 @@ tree = MeshToCGNS(Mesh)
 # Display CGNS Tree
 CGH.show_cgns_tree(tree)
 
+# %%
+# Print CGNS tree summary for a concise overview
+CGH.summarize_cgns_tree(tree, verbose=True)
+
 # %% [markdown]
 # ### Initialize a new empty Sample and print it
 

--- a/src/plaid/utils/cgns_helper.py
+++ b/src/plaid/utils/cgns_helper.py
@@ -131,6 +131,7 @@ def summarize_cgns_tree(pyTree: list, verbose=True) -> str:
     base_paths = CGU.getPathsByTypeSet(pyTree, "CGNSBase_t")
     nb_base = len(base_paths)
     nb_zones = 0
+    nb_nodes = 0
     nb_elements = 0
     nb_fields = 0
     fields = []
@@ -147,13 +148,9 @@ def summarize_cgns_tree(pyTree: list, verbose=True) -> str:
         for zone_path in zone_paths:
             zone_node = CGU.getNodeByPath(base_node, zone_path)
             zone_name = zone_node[0]
-
-            # Elements
-            elem_paths = CGU.getPathsByTypeSet(zone_node, "Elements_t")
-            if elem_paths:
-                for elem_path in elem_paths:
-                    elem_node = CGU.getNodeByPath(zone_node, elem_path)
-                    nb_elements += elem_node[1][0]
+            # Read number of nodes and elements from the Zone node
+            nb_nodes += zone_node[1][0][0]
+            nb_elements += zone_node[1][0][1]
 
             # Flow Solutions (Fields)
             sol_paths = CGU.getPathsByTypeSet(zone_node, "FlowSolution_t")
@@ -167,6 +164,7 @@ def summarize_cgns_tree(pyTree: list, verbose=True) -> str:
 
     summary.append(f"Number of Bases: {nb_base}")
     summary.append(f"Number of Zones: {nb_zones}")
+    summary.append(f"Number of Nodes: {nb_nodes}")
     summary.append(f"Number of Elements: {nb_elements}")
     summary.append(f"Number of Fields: {nb_fields}")
     summary.append("")

--- a/src/plaid/utils/cgns_helper.py
+++ b/src/plaid/utils/cgns_helper.py
@@ -114,12 +114,8 @@ def summarize_cgns_tree(pyTree: list, verbose=True) -> str:
         pyTree (list): The CGNS tree to summarize.
         verbose (bool, optional): If True, include detailed field information. Defaults to True.
 
-    Returns:
-        str: A string containing the summary.
-
     Example:
-        >>> summary = summarize_cgns_tree(pyTree)
-        >>> print(summary)
+        >>> summarize_cgns_tree(pyTree)
         Number of Bases: 2
         Number of Zones: 5
         Number of Elements: 10

--- a/src/plaid/utils/cgns_helper.py
+++ b/src/plaid/utils/cgns_helper.py
@@ -173,8 +173,6 @@ def summarize_cgns_tree(pyTree: list, verbose=True) -> str:
         summary.append("Fields :")
         for field_names, sol_name, zone_name, base_name in fields:
             for field_name in field_names:
-                if field_name.startswith("Coordinate"):
-                    continue
                 summary.append(f"  {base_name}/{zone_name}/{sol_name}/{field_name}")
 
     print("\n".join(summary))

--- a/src/plaid/utils/cgns_helper.py
+++ b/src/plaid/utils/cgns_helper.py
@@ -118,6 +118,7 @@ def summarize_cgns_tree(pyTree: list, verbose=True) -> str:
         >>> summarize_cgns_tree(pyTree)
         Number of Bases: 2
         Number of Zones: 5
+        Number of Nodes: 20
         Number of Elements: 10
         Number of Fields: 8
 

--- a/tests/problem_definition/problem_infos.yaml
+++ b/tests/problem_definition/problem_infos.yaml
@@ -13,8 +13,8 @@ input_fields:
 - test_field
 output_fields:
 - field
-- test_field
 - predict_field
+- test_field
 input_timeseries:
 - predict_timeseries
 - test_timeseries

--- a/tests/utils/test_cgns_helper.py
+++ b/tests/utils/test_cgns_helper.py
@@ -9,7 +9,12 @@
 
 import pytest
 
-from plaid.utils.cgns_helper import get_base_names, get_time_values, show_cgns_tree
+from plaid.utils.cgns_helper import (
+    get_base_names,
+    get_time_values,
+    show_cgns_tree,
+    summarize_cgns_tree,
+)
 
 
 # %% Tests
@@ -45,3 +50,9 @@ class Test_cgns_helper:
     def test_show_cgns_tree_not_a_list(self):
         with pytest.raises(TypeError):
             show_cgns_tree({1: 2})
+
+    def test_summarize_cgns_tree(self, tree):
+        summarize_cgns_tree(tree, verbose=False)
+
+    def test_summarize_cgns_tree_verbose(self, tree):
+        summarize_cgns_tree(tree, verbose=True)


### PR DESCRIPTION
Adds a 'summarize_cgns_tree' function in order to display general information about a CGNS Tree.

Example Output (from 'examples/containers/sample_example.py'):
```
Number of Bases: 1
Number of Zones: 1
Number of Elements: 5
Number of Fields: 8

Fields :
  Base_2_2/Zone/PointData/GridLocation
  Base_2_2/Zone/PointData/OriginalIds
  Base_2_2/Zone/PointData/test_node_field_1
  Base_2_2/Zone/CellData/GridLocation
  Base_2_2/Zone/CellData/OriginalIds
  Base_2_2/Zone/CellData/test_elem_field_1
  Base_2_2/Zone/SurfaceData/GridLocation
  Base_2_2/Zone/SurfaceData/OriginalIds
```

The function also has a parameter to hide the "Fields:" section if necessary.

This PR closes #94 