### PR TITLE
📄 docs(dataset): add __iter__ examples for Dataset

### DIFF
--- a/docs/source/notebooks/dataset.ipynb
+++ b/docs/source/notebooks/dataset.ipynb
@@ -281,6 +281,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Iterate through Samples in the Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for sample in dataset:\n",
+    "    print(sample)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Add and display information to the Dataset"
    ]
   },

--- a/examples/containers/dataset_example.py
+++ b/examples/containers/dataset_example.py
@@ -163,6 +163,13 @@ added_sample_id = dataset.add_sample(sample_03)
 print(f"{added_sample_id = }")
 
 # %% [markdown]
+# ### Iterate through Samples in the Dataset
+
+# %%
+for sample in dataset:
+    print(sample)
+
+# %% [markdown]
 # ### Add and display information to the Dataset
 
 # %%

--- a/src/plaid/containers/dataset.py
+++ b/src/plaid/containers/dataset.py
@@ -99,6 +99,11 @@ class Dataset(object):
                 >>> Dataset(3 samples, 2 scalars, 5 fields)
                 print(len(dataset))
                 >>> 3
+                for sample in dataset:
+                    print(sample)
+                >>> Sample(1 scalar, 0 time series, 1 timestamp, 2 fields)
+                    Sample(1 scalar, 0 time series, 0 timestamps, 0 fields)
+                    Sample(2 scalars, 0 time series, 1 timestamp, 2 fields)
 
         Caution:
             It is assumed that you provided a compatible PLAID dataset.


### PR DESCRIPTION
Adds simple __iter__ examples inside notebooks, examples and docstrings.

I kept it simple, don't hesitate to tell me if you have anything that would be interesting to add or to detail more.

(Also, some docstrings are not following standards with '>>>' and '...' and some are, I might create an issue to address this later)

Closes #84