### PR TITLE
📄 feat(docs) add version to docs and rtd full git depth

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,9 @@
 
 version: 2
 
+git:
+  depth: full
+
 sphinx:
   configuration: docs/conf.py
 
@@ -19,3 +22,9 @@ python:
   install:
     - method: pip
       path: .
+
+versions:
+  only:
+    - latest
+    - 0.1.6
+    - 0.1.5

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -22,9 +22,3 @@ python:
   install:
     - method: pip
       path: .
-
-versions:
-  only:
-    - latest
-    - 0.1.6
-    - 0.1.5

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,7 @@
 import datetime
 import os
 import sys
+import subprocess
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -228,3 +229,35 @@ def skip_logger_attribute(app, what, name, obj, skip, options):
 
 def setup(sphinx):
     sphinx.connect("autoapi-skip-member", skip_logger_attribute)
+
+
+# -----------------------------------------------------------------------------#
+
+
+# def get_git_version():
+#     try:
+#         # Try to get exact tag first
+#         version = subprocess.check_output(
+#             ["git", "describe", "--tags", "--exact-match"],
+#             stderr=subprocess.STDOUT,
+#         ).decode().strip()
+#         return version
+#     except subprocess.CalledProcessError:
+#         # No tag, get branch name
+#         try:
+#             branch = subprocess.check_output(
+#                 ["git", "rev-parse", "--abbrev-ref", "HEAD"]
+#             ).decode().strip()
+#         except Exception:
+#             branch = "unknown-branch"
+#         # Get short commit hash
+#         try:
+#             commit_hash = subprocess.check_output(
+#                 ["git", "rev-parse", "--short", "HEAD"]
+#             ).decode().strip()
+#         except Exception:
+#             commit_hash = "unknown-hash"
+
+#         return f"{branch}-{commit_hash}"
+
+# version = get_git_version()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -233,31 +233,49 @@ def setup(sphinx):
 
 # -----------------------------------------------------------------------------#
 
-def get_git_version():
+def get_git_info():
+
     try:
-        # Try to get exact tag first
-        version = subprocess.check_output(
-            ["git", "describe", "--tags", "--exact-match"],
-            stderr=subprocess.STDOUT,
-        ).decode().strip()
-        return version
+        # Try exact tag on current commit
+        tag = subprocess.check_output(
+            ['git', 'describe', '--tags', '--exact-match'],
+            stderr=subprocess.DEVNULL,
+            text=True
+        ).strip()
+        if tag:
+            print(f"I found an ecat tag: {tag}")
+            return tag
     except subprocess.CalledProcessError:
-        # No tag, get branch name
-        try:
+        # No exact tag on this commit, fallback below
+        pass
+
+    try:
+        rtd_version = os.environ.get("READTHEDOCS_VERSION")
+
+        if rtd_version == "latest":
+            rtd_version = "main"
+
+        # Get branch from RTD env or local git
+        branch = rtd_version
+        if not branch:
             branch = subprocess.check_output(
-                ["git", "rev-parse", "--abbrev-ref", "HEAD"]
-            ).decode().strip()
-        except Exception:
-            branch = "unknown-branch"
+                ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+                stderr=subprocess.DEVNULL,
+                text=True
+            ).strip()
+
         # Get short commit hash
-        try:
-            commit_hash = subprocess.check_output(
-                ["git", "rev-parse", "--short", "HEAD"]
-            ).decode().strip()
-        except Exception:
-            commit_hash = "unknown-hash"
+        commit = subprocess.check_output(
+            ['git', 'rev-parse', '--short', 'HEAD'],
+            stderr=subprocess.DEVNULL,
+            text=True
+        ).strip()
 
-        return f"{branch}-{commit_hash}"
+        return f"{branch}-{commit}"
 
-release = get_git_version()
+
+    except Exception:
+        return "unknown"
+
+release = get_git_info()
 version = release

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -233,31 +233,31 @@ def setup(sphinx):
 
 # -----------------------------------------------------------------------------#
 
+def get_git_version():
+    try:
+        # Try to get exact tag first
+        version = subprocess.check_output(
+            ["git", "describe", "--tags", "--exact-match"],
+            stderr=subprocess.STDOUT,
+        ).decode().strip()
+        return version
+    except subprocess.CalledProcessError:
+        # No tag, get branch name
+        try:
+            branch = subprocess.check_output(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"]
+            ).decode().strip()
+        except Exception:
+            branch = "unknown-branch"
+        # Get short commit hash
+        try:
+            commit_hash = subprocess.check_output(
+                ["git", "rev-parse", "--short", "HEAD"]
+            ).decode().strip()
+        except Exception:
+            commit_hash = "unknown-hash"
 
-# def get_git_version():
-#     try:
-#         # Try to get exact tag first
-#         version = subprocess.check_output(
-#             ["git", "describe", "--tags", "--exact-match"],
-#             stderr=subprocess.STDOUT,
-#         ).decode().strip()
-#         return version
-#     except subprocess.CalledProcessError:
-#         # No tag, get branch name
-#         try:
-#             branch = subprocess.check_output(
-#                 ["git", "rev-parse", "--abbrev-ref", "HEAD"]
-#             ).decode().strip()
-#         except Exception:
-#             branch = "unknown-branch"
-#         # Get short commit hash
-#         try:
-#             commit_hash = subprocess.check_output(
-#                 ["git", "rev-parse", "--short", "HEAD"]
-#             ).decode().strip()
-#         except Exception:
-#             commit_hash = "unknown-hash"
+        return f"{branch}-{commit_hash}"
 
-#         return f"{branch}-{commit_hash}"
-
-# version = get_git_version()
+release = get_git_version()
+version = release


### PR DESCRIPTION
It's not clear which version of the code corresponds to the doc being consulted on readthedocs. With these modifications, here what it would look like:

- If a tag exists at the corresponding commit (stable version, or tagged versions):
<img width="1417" height="333" alt="image" src="https://github.com/user-attachments/assets/946987ac-ebad-4cfc-a939-0a191c674ee6" />

- If no tag (latest version -> rtd will become main, with commit hash):
<img width="1418" height="454" alt="image" src="https://github.com/user-attachments/assets/ff6922cf-81a6-4000-a1a8-b0e1786fcf89" />

And I set stable to the default version on readthedocs.