### PR TITLE
♻️ Refactor: Rename methods for clarity (#195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move to Muscat=2.5.0 (for tests and examples support)
 - Update repo configuration (actions: rely more on pypi dependencies, action versions)
 - Rename types to remove `Type` from name of types: https://github.com/PLAID-lib/plaid/pull/164
+- Refactored method names for improved clarity:
+  - `Dataset.from_tabular` → `Dataset.add_features_from_tabular`
+  - `Dataset.from_features_identifier` → `Dataset.extract_dataset_from_identifier`  
+  - `Sample.from_features_identifier` → `Sample.extract_sample_from_identifier`
 
 ### Fixes
 

--- a/examples/pipelines/pipeline_example.py
+++ b/examples/pipelines/pipeline_example.py
@@ -114,7 +114,7 @@ all_feature_id = config['input_scalar_scaler']['in_features_identifiers'] +\
 # In this example, we aim to predict the ``mach`` field based on two input scalars ``angle_in`` and ``mach_out``, and the mesh node coordinates. To contain memory consumption, we restrict the dataset to the features required for this example:
 
 # %%
-dataset_train = dataset_train.from_features_identifier(all_feature_id)
+dataset_train = dataset_train.extract_dataset_from_identifier(all_feature_id)
 print("dataset_train:", dataset_train)
 print("scalar names =", dataset_train.get_scalar_names())
 print("field names =", dataset_train.get_field_names())

--- a/src/plaid/containers/dataset.py
+++ b/src/plaid/containers/dataset.py
@@ -34,6 +34,7 @@ from plaid.containers.sample import Sample
 from plaid.containers.utils import check_features_size_homogeneity
 from plaid.types import Array, Feature, FeatureIdentifier
 from plaid.utils.base import DeprecatedError, ShapeError, generate_random_ASCII
+from plaid.utils.deprecation import deprecated
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(
@@ -662,7 +663,7 @@ class Dataset(object):
             )
         return dataset
 
-    def from_features_identifier(
+    def extract_dataset_from_identifier(
         self,
         feature_identifiers: Union[FeatureIdentifier, list[FeatureIdentifier]],
     ) -> Self:
@@ -684,9 +685,25 @@ class Dataset(object):
         dataset.set_infos(copy.deepcopy(self.get_infos()))
 
         for id in self.get_sample_ids():
-            extracted_sample = self[id].from_features_identifier(feature_identifiers)
+            extracted_sample = self[id].extract_sample_from_identifier(
+                feature_identifiers
+            )
             dataset.add_sample(sample=extracted_sample, id=id)
         return dataset
+
+    @deprecated(
+        "Use extract_dataset_from_identifier() instead",
+        version="0.1.8",
+        removal="0.2",
+    )
+    def from_features_identifier(
+        self,
+        feature_identifiers: Union[FeatureIdentifier, list[FeatureIdentifier]],
+    ) -> Self:
+        """DEPRECATED: Use extract_dataset_from_identifier() instead."""
+        return self.extract_dataset_from_identifier(
+            feature_identifiers
+        )  # pragma: no cover
 
     def get_tabular_from_homogeneous_identifiers(
         self,
@@ -744,22 +761,28 @@ class Dataset(object):
 
         return tabular
 
-    def from_tabular(
+    def add_features_from_tabular(
         self,
         tabular: Array,
         feature_identifiers: Union[FeatureIdentifier, list[FeatureIdentifier]],
         restrict_to_features: bool = True,
     ) -> Self:
-        """Generates a dataset from tabular data and feature_identifiers.
+        """Add or update features in the dataset from tabular data using feature identifiers.
+
+        This method takes tabular data and applies it to the dataset, either by updating existing features
+        or adding new ones based on the provided feature identifiers. The method can either:
+        1. Extract only the specified features and return a new dataset with just those features (if restrict_to_features=True)
+        2. Update the specified features in the current dataset while keeping all other existing features (if restrict_to_features=False)
 
         Parameters:
             tabular (Array): of size (nb_sample, nb_features) or (nb_sample, nb_features, dim_feature) if dim_feature>1
-            feature_identifiers (dict or list of dict): One or more feature identifiers.
-            extract_features (bool, optional): If True, only returns the features from feature identifiers, otherwise keep the other features as well
+            feature_identifiers (dict or list of dict): One or more feature identifiers specifying which features to update/add.
+            restrict_to_features (bool, optional): If True, only returns the features from feature identifiers, otherwise keep the other features as well. Defaults to True.
 
         Returns:
-            Self
-                A new dataset defined from tabular data and feature_identifiers.
+            Self: A new dataset with features updated/added from the tabular data. If restrict_to_features=True,
+                  contains only the specified features. If restrict_to_features=False, contains all original
+                  features plus the updated/added ones.
 
         Raises:
             AssertionError
@@ -775,7 +798,7 @@ class Dataset(object):
         features = {id: tabular[i] for i, id in enumerate(self.get_sample_ids())}
 
         if restrict_to_features:
-            dataset = self.from_features_identifier(feature_identifiers)
+            dataset = self.extract_dataset_from_identifier(feature_identifiers)
             dataset.update_features_from_identifier(
                 feature_identifiers=feature_identifiers,
                 features=features,
@@ -789,6 +812,22 @@ class Dataset(object):
             )
 
         return dataset
+
+    @deprecated(
+        "Use add_features_from_tabular() instead",
+        version="0.1.8",
+        removal="0.2",
+    )
+    def from_tabular(
+        self,
+        tabular: Array,
+        feature_identifiers: Union[FeatureIdentifier, list[FeatureIdentifier]],
+        restrict_to_features: bool = True,
+    ) -> Self:
+        """DEPRECATED: Use add_features_from_tabular() instead."""
+        return self.add_features_from_tabular(
+            tabular, feature_identifiers, restrict_to_features
+        )  # pragma: no cover
 
     # -------------------------------------------------------------------------#
     def add_info(self, cat_key: str, info_key: str, info: str) -> None:

--- a/src/plaid/containers/sample.py
+++ b/src/plaid/containers/sample.py
@@ -52,6 +52,7 @@ from plaid.types import (
 )
 from plaid.utils import cgns_helper as CGH
 from plaid.utils.base import safe_len
+from plaid.utils.deprecation import deprecated
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(
@@ -1061,7 +1062,7 @@ class Sample(BaseModel):
 
         return sample
 
-    def from_features_identifier(
+    def extract_sample_from_identifier(
         self,
         feature_identifiers: Union[FeatureIdentifier, list[FeatureIdentifier]],
     ) -> Self:
@@ -1112,6 +1113,20 @@ class Sample(BaseModel):
         sample._extra_data = copy.deepcopy(self._extra_data)
 
         return sample
+
+    @deprecated(
+        "Use extract_sample_from_identifier() instead",
+        version="0.1.8",
+        removal="0.2",
+    )
+    def from_features_identifier(
+        self,
+        feature_identifiers: Union[FeatureIdentifier, list[FeatureIdentifier]],
+    ) -> Self:
+        """DEPRECATED: Use extract_sample_from_identifier() instead."""
+        return self.extract_sample_from_identifier(
+            feature_identifiers
+        )  # pragma: no cover
 
     def merge_features(self, sample: Self, in_place: bool = False) -> Self:
         """Merge features from another sample into the current sample.

--- a/src/plaid/pipelines/plaid_blocks.py
+++ b/src/plaid/pipelines/plaid_blocks.py
@@ -96,7 +96,7 @@ class ColumnTransformer(ColumnTransformer):
                 if isinstance(transformer, Pipeline)
                 else transformer.in_features_identifiers
             )
-            sub_dataset = dataset.from_features_identifier(in_feat_id)
+            sub_dataset = dataset.extract_dataset_from_identifier(in_feat_id)
             transformer_ = clone(transformer).fit(sub_dataset)
             self.transformers_.append((name, transformer_, "_"))
 
@@ -136,7 +136,7 @@ class ColumnTransformer(ColumnTransformer):
                 if isinstance(transformer_, Pipeline)
                 else transformer_.in_features_identifiers_
             )
-            sub_dataset = dataset.from_features_identifier(in_feat_id)
+            sub_dataset = dataset.extract_dataset_from_identifier(in_feat_id)
             transformed = transformer_.transform(sub_dataset)
             transformed_datasets.append(transformed)
         return Dataset.merge_dataset_by_features(transformed_datasets)
@@ -174,7 +174,7 @@ class ColumnTransformer(ColumnTransformer):
                 if isinstance(transformer_, Pipeline)
                 else transformer_.in_features_identifiers_
             )
-            sub_dataset = dataset.from_features_identifier(in_feat_id)
+            sub_dataset = dataset.extract_dataset_from_identifier(in_feat_id)
             transformed = transformer_.inverse_transform(sub_dataset)
             transformed_datasets.append(transformed)
         return Dataset.merge_dataset_by_features(transformed_datasets)

--- a/src/plaid/pipelines/sklearn_block_wrappers.py
+++ b/src/plaid/pipelines/sklearn_block_wrappers.py
@@ -141,7 +141,7 @@ class WrappedSklearnTransformer(TransformerMixin, BaseEstimator):
             (len(dataset), len(self.out_features_identifiers_), -1)
         )
 
-        dataset_transformed = dataset.from_tabular(
+        dataset_transformed = dataset.add_features_from_tabular(
             X_transformed, self.out_features_identifiers_, restrict_to_features=False
         )
 
@@ -168,7 +168,7 @@ class WrappedSklearnTransformer(TransformerMixin, BaseEstimator):
             (len(dataset), len(self.in_features_identifiers_), -1)
         )
 
-        dataset_inv_transformed = dataset.from_tabular(
+        dataset_inv_transformed = dataset.add_features_from_tabular(
             X_inv_transformed, self.in_features_identifiers_, restrict_to_features=False
         )
 
@@ -236,7 +236,7 @@ class WrappedSklearnRegressor(RegressorMixin, BaseEstimator):
         y = self.sklearn_block_.predict(X)
         y = y.reshape((len(dataset), len(self.out_features_identifiers_), -1))
 
-        dataset_predicted = dataset.from_tabular(
+        dataset_predicted = dataset.add_features_from_tabular(
             y, self.out_features_identifiers_, restrict_to_features=False
         )
 

--- a/tests/containers/test_dataset.py
+++ b/tests/containers/test_dataset.py
@@ -663,17 +663,17 @@ class Test_Dataset:
             in_place=True,
         )
 
-    def test_from_features_identifier(
+    def test_extract_dataset_from_identifier(
         self, dataset_with_samples, dataset_with_samples_with_tree
     ):
-        dataset_with_samples.from_features_identifier(
+        dataset_with_samples.extract_dataset_from_identifier(
             feature_identifiers={"type": "scalar", "name": "test_scalar"},
         )
-        dataset_with_samples.from_features_identifier(
+        dataset_with_samples.extract_dataset_from_identifier(
             feature_identifiers={"type": "time_series", "name": "test_time_series_1"},
         )
 
-        dataset_with_samples_with_tree.from_features_identifier(
+        dataset_with_samples_with_tree.extract_dataset_from_identifier(
             feature_identifiers={
                 "type": "field",
                 "name": "test_node_field_1",
@@ -684,7 +684,7 @@ class Test_Dataset:
             },
         )
 
-        dataset_with_samples_with_tree.from_features_identifier(
+        dataset_with_samples_with_tree.extract_dataset_from_identifier(
             feature_identifiers=[
                 {"type": "field", "name": "test_node_field_1"},
                 {"type": "nodes"},
@@ -765,14 +765,14 @@ class Test_Dataset:
                 ],
             )
 
-    def test_from_tabular(self, dataset_with_samples_with_tree):
+    def test_add_features_from_tabular(self, dataset_with_samples_with_tree):
         X = dataset_with_samples_with_tree.get_tabular_from_homogeneous_identifiers(
             feature_identifiers=[
                 {"type": "field", "name": "test_node_field_1"},
                 {"type": "field", "name": "OriginalIds"},
             ],
         )
-        dataset = dataset_with_samples_with_tree.from_tabular(
+        dataset = dataset_with_samples_with_tree.add_features_from_tabular(
             tabular=X,
             feature_identifiers=[
                 {"type": "field", "name": "test_node_field_1"},
@@ -804,7 +804,7 @@ class Test_Dataset:
                 {"type": "field", "name": "OriginalIds"},
             ],
         )
-        dataset = dataset_with_samples_with_tree.from_tabular(
+        dataset = dataset_with_samples_with_tree.add_features_from_tabular(
             tabular=X,
             feature_identifiers=[
                 {"type": "field", "name": "test_node_field_1"},
@@ -830,7 +830,7 @@ class Test_Dataset:
             dataset_with_samples_with_tree[last_index].get_field("test_node_field_1"),
         ).all()
 
-        dataset = dataset_with_samples_with_tree.from_tabular(
+        dataset = dataset_with_samples_with_tree.add_features_from_tabular(
             tabular=X,
             feature_identifiers={"type": "field", "name": "OriginalIds"},
         )
@@ -894,10 +894,10 @@ class Test_Dataset:
         feat_id = [
             fid for fid in feat_id if fid["type"] not in ["scalar", "time_series"]
         ]
-        dataset_1 = dataset_with_samples.from_features_identifier(feat_id)
+        dataset_1 = dataset_with_samples.extract_dataset_from_identifier(feat_id)
         feat_id = other_dataset_with_samples.get_all_features_identifiers()
         feat_id = [fid for fid in feat_id if fid["type"] not in ["field", "node"]]
-        dataset_2 = other_dataset_with_samples.from_features_identifier(feat_id)
+        dataset_2 = other_dataset_with_samples.extract_dataset_from_identifier(feat_id)
         dataset_merge_1 = dataset_1.merge_features(dataset_2, in_place=False)
         dataset_merge_2 = dataset_2.merge_features(dataset_1, in_place=False)
         assert (

--- a/tests/containers/test_sample.py
+++ b/tests/containers/test_sample.py
@@ -1202,54 +1202,67 @@ class Test_Sample:
         ref_2 = sample_.get_field("test_node_field_1")
         assert np.any(np.isclose(ref_1, ref_2))
 
-    def test_from_features_identifier(
+    def test_extract_sample_from_identifier(
         self, sample_with_tree_and_scalar_and_time_series
     ):
-        sample_ = sample_with_tree_and_scalar_and_time_series.from_features_identifier(
-            feature_identifiers={"type": "scalar", "name": "test_scalar_1"},
+        sample_ = (
+            sample_with_tree_and_scalar_and_time_series.extract_sample_from_identifier(
+                feature_identifiers={"type": "scalar", "name": "test_scalar_1"},
+            )
         )
         assert sample_.get_scalar_names() == ["test_scalar_1"]
         assert len(sample_.get_time_series_names()) == 0
         assert len(sample_.get_field_names()) == 0
 
-        sample_ = sample_with_tree_and_scalar_and_time_series.from_features_identifier(
-            feature_identifiers={"type": "time_series", "name": "test_time_series_1"},
+        sample_ = (
+            sample_with_tree_and_scalar_and_time_series.extract_sample_from_identifier(
+                feature_identifiers={
+                    "type": "time_series",
+                    "name": "test_time_series_1",
+                },
+            )
         )
         assert len(sample_.get_scalar_names()) == 0
         assert sample_.get_time_series_names() == ["test_time_series_1"]
         assert len(sample_.get_field_names()) == 0
 
-        sample_ = sample_with_tree_and_scalar_and_time_series.from_features_identifier(
-            feature_identifiers={
-                "type": "field",
-                "name": "test_node_field_1",
-                "base_name": "Base_2_2",
-                "zone_name": "Zone",
-                "location": "Vertex",
-                "time": 0.0,
-            },
+        sample_ = (
+            sample_with_tree_and_scalar_and_time_series.extract_sample_from_identifier(
+                feature_identifiers={
+                    "type": "field",
+                    "name": "test_node_field_1",
+                    "base_name": "Base_2_2",
+                    "zone_name": "Zone",
+                    "location": "Vertex",
+                    "time": 0.0,
+                },
+            )
         )
         assert len(sample_.get_scalar_names()) == 0
         assert len(sample_.get_time_series_names()) == 0
         assert sample_.get_field_names() == ["test_node_field_1"]
 
-        sample_ = sample_with_tree_and_scalar_and_time_series.from_features_identifier(
-            feature_identifiers={
-                "type": "nodes",
-                "base_name": "Base_2_2",
-                "zone_name": "Zone",
-                "time": 0.0,
-            },
+        sample_ = (
+            sample_with_tree_and_scalar_and_time_series.extract_sample_from_identifier(
+                feature_identifiers={
+                    "type": "nodes",
+                    "base_name": "Base_2_2",
+                    "zone_name": "Zone",
+                    "time": 0.0,
+                },
+            )
         )
         assert len(sample_.get_scalar_names()) == 0
         assert len(sample_.get_time_series_names()) == 0
         assert len(sample_.get_field_names()) == 0
 
-        sample_ = sample_with_tree_and_scalar_and_time_series.from_features_identifier(
-            feature_identifiers=[
-                {"type": "field", "name": "test_node_field_1"},
-                {"type": "nodes"},
-            ],
+        sample_ = (
+            sample_with_tree_and_scalar_and_time_series.extract_sample_from_identifier(
+                feature_identifiers=[
+                    {"type": "field", "name": "test_node_field_1"},
+                    {"type": "nodes"},
+                ],
+            )
         )
         assert len(sample_.get_scalar_names()) == 0
         assert len(sample_.get_time_series_names()) == 0
@@ -1367,12 +1380,14 @@ class Test_Sample:
         feat_id = [
             fid for fid in feat_id if fid["type"] not in ["scalar", "time_series"]
         ]
-        sample_1 = sample_with_tree_and_scalar_and_time_series.from_features_identifier(
-            feat_id
+        sample_1 = (
+            sample_with_tree_and_scalar_and_time_series.extract_sample_from_identifier(
+                feat_id
+            )
         )
         feat_id = sample_with_tree.get_all_features_identifiers()
         feat_id = [fid for fid in feat_id if fid["type"] not in ["field", "node"]]
-        sample_2 = sample_with_tree.from_features_identifier(feat_id)
+        sample_2 = sample_with_tree.extract_sample_from_identifier(feat_id)
         sample_merge_1 = sample_1.merge_features(sample_2, in_place=False)
         sample_merge_2 = sample_2.merge_features(sample_1, in_place=False)
         assert (


### PR DESCRIPTION
PR for issue #195:  Refactors method names for improved clarity:
  - `Dataset.from_tabular` → `Dataset.add_features_from_tabular`
  - `Dataset.from_features_identifier` → `Dataset.extract_dataset_from_identifier`  
  - `Sample.from_features_identifier` → `Sample.extract_sample_from_identifier`

### Checklist

- [x] Typing enforced
- [x] Documentation updated
- [x] Changelog updated
- [x] Tests and Example updates
- [ ] Coverage should be 100%