### PR TITLE
:recycle: Improve some type hints in storage module

### DIFF
--- a/src/plaid/storage/cgns/reader.py
+++ b/src/plaid/storage/cgns/reader.py
@@ -140,6 +140,9 @@ class CGNSDataset:
         return f"<CGNSDataset {repr(self.path)} | extra_fields={self._extra_fields}>"
 
 
+CGNSDatasetDict = dict[str, CGNSDataset]
+
+
 def sample_generator(
     repo_id: str, split: str, ids: Iterable[int]
 ) -> Iterator[Sample]:  # pragma: no cover
@@ -203,7 +206,7 @@ def create_CGNS_iterable_dataset(
 
 def init_datasetdict_from_disk(
     path: Union[str, Path],
-) -> dict[str, CGNSDataset]:
+) -> CGNSDatasetDict:
     """Initialize a dataset dictionary from local disk.
 
     This function scans a local directory structure and creates CGNSDataset objects
@@ -214,7 +217,7 @@ def init_datasetdict_from_disk(
             with split subdirectories.
 
     Returns:
-        dict[str, CGNSDataset]: Dictionary mapping split names to CGNSDataset objects.
+        CGNSDatasetDict: Dictionary mapping split names to CGNSDataset objects.
     """
     local_path = Path(path) / "data"
     split_names = [p.name for p in local_path.iterdir() if p.is_dir()]
@@ -232,7 +235,7 @@ def download_datasetdict_from_hub(
     split_ids: Optional[dict[str, Iterable[int]]] = None,
     features: Optional[list[str]] = None,  # noqa: ARG001
     overwrite: bool = False,
-) -> None:  # pragma: no cover
+) -> str:  # pragma: no cover
     """Download a CGNS dataset from Hugging Face Hub to local disk.
 
     This function downloads selected parts or the entire CGNS dataset from a Hugging Face
@@ -245,6 +248,9 @@ def download_datasetdict_from_hub(
             If None, downloads all splits and samples.
         features: Optional list of features to download (currently unused).
         overwrite: If True, removes existing local directory before downloading.
+
+    Returns:
+        str: Path to the local directory where the dataset has been downloaded.
     """
     output_folder = Path(local_dir)
 
@@ -264,7 +270,7 @@ def download_datasetdict_from_hub(
     else:
         allow_patterns = ["data/*"]
 
-    snapshot_download(
+    return snapshot_download(
         repo_id=repo_id,
         repo_type="dataset",
         allow_patterns=allow_patterns,

--- a/src/plaid/storage/hf_datasets/bridge.py
+++ b/src/plaid/storage/hf_datasets/bridge.py
@@ -217,17 +217,17 @@ def to_var_sample_dict(
     i: int,
     features: Optional[list[str]] = None,
     enforce_shapes: bool = True,
-) -> dict[str, Any]:
+) -> dict[str, Optional[np.ndarray]]:
     """Convert a Hugging Face dataset row to a variable sample dict containing the features that vary in the dataset.
 
     Args:
         ds (datasets.Dataset): The Hugging Face dataset.
         i (int): The row index.
-        enforce_shapes (bool): Whether to enforce consistent shapes.
         features: Iterable of feature names (keys) to extract from the dataset.
+        enforce_shapes (bool): Whether to enforce consistent shapes.
 
     Returns:
-        dict: The variable sample dictionary.
+        dict[str, Optional[np.ndarray]]: The variable sample dictionary.
     """
     table = ds.data
 

--- a/src/plaid/storage/hf_datasets/reader.py
+++ b/src/plaid/storage/hf_datasets/reader.py
@@ -37,15 +37,17 @@ logger = logging.getLogger(__name__)
 # Load from disk
 # ------------------------------------------------------
 
+HFDatasetDict = dict[str, datasets.DatasetDict]
 
-def init_datasetdict_from_disk(path: Union[str, Path]) -> datasets.DatasetDict:
+
+def init_datasetdict_from_disk(path: Union[str, Path]) -> HFDatasetDict:
     """Initializes a DatasetDict from local disk files.
 
     Args:
         path (Union[str, Path]): Path to the directory containing the dataset files.
 
     Returns:
-        datasets.DatasetDict: The loaded dataset dictionary.
+        HFDatasetDict: The loaded dataset dictionary.
     """
     file_ = Path(path) / "data" / "dataset_dict.json"
 

--- a/src/plaid/storage/reader.py
+++ b/src/plaid/storage/reader.py
@@ -194,7 +194,7 @@ class Converter:
 
 def init_from_disk(
     local_dir: Union[Path, str],
-) -> tuple[dict[str, Any], dict[str, "Converter"]]:
+) -> tuple[dict[str, Any], dict[str, Converter]]:
     """Initialize dataset and converters from local disk.
 
     This function loads a previously saved PLAID dataset from local disk, automatically

--- a/src/plaid/storage/registry.py
+++ b/src/plaid/storage/registry.py
@@ -12,7 +12,14 @@ source of truth for backend capabilities.
 """
 
 from dataclasses import dataclass
-from typing import Any, Callable, Optional
+from pathlib import Path
+from typing import Any, Callable, Optional, Union
+
+import datasets
+
+from plaid.storage.cgns.reader import CGNSDatasetDict
+from plaid.storage.hf_datasets.reader import HFDatasetDict
+from plaid.storage.zarr.reader import ZarrDatasetDict
 
 from . import cgns, hf_datasets, zarr
 
@@ -22,12 +29,16 @@ class BackendSpec:
     """Backend wiring for storage operations."""
 
     name: str
-    init_from_disk: Callable[..., Any]
-    download_from_hub: Callable[..., Any]
-    init_streaming_from_hub: Callable[..., Any]
-    generate_to_disk: Callable[..., Any]
-    push_local_to_hub: Callable[..., Any]
-    configure_dataset_card: Callable[..., Any]
+    init_from_disk: Callable[
+        [Union[str, Path]], Union[CGNSDatasetDict, HFDatasetDict, ZarrDatasetDict]
+    ]
+    download_from_hub: Callable[..., str]
+    init_streaming_from_hub: Callable[
+        ..., dict[str, datasets.IterableDataset] | datasets.IterableDatasetDict
+    ]
+    generate_to_disk: Callable[..., None]
+    push_local_to_hub: Callable[..., None]
+    configure_dataset_card: Callable[..., None]
     to_var_sample_dict: Optional[Callable[..., dict[str, Any]]]
     sample_to_var_sample_dict: Optional[Callable[..., dict[str, Any]]]
 

--- a/src/plaid/storage/zarr/reader.py
+++ b/src/plaid/storage/zarr/reader.py
@@ -18,7 +18,6 @@ Key features:
 # file 'LICENSE.txt', which is part of this source code package.
 #
 #
-
 import logging
 import os
 import shutil
@@ -256,17 +255,19 @@ def create_zarr_iterable_dataset(
 # Load from disk
 # ------------------------------------------------------
 
+ZarrDatasetDict = dict[str, ZarrDataset]
+
 
 def init_datasetdict_from_disk(
     path: Union[str, Path],
-) -> dict[str, ZarrDataset]:
+) -> ZarrDatasetDict:
     """Initializes dataset dictionaries from local Zarr files.
 
     Args:
         path (Union[str, Path]): Path to the local directory containing the dataset.
 
     Returns:
-        dict[str, ZarrDataset]: Dictionary mapping split names to ZarrDataset objects.
+        ZarrDatasetDict: Dictionary mapping split names to ZarrDataset objects.
     """
     local_path = Path(path) / "data"
     split_names = [p.name for p in local_path.iterdir() if p.is_dir()]
@@ -289,7 +290,7 @@ def download_datasetdict_from_hub(
     split_ids: Optional[dict[str, list[int]]] = None,
     features: Optional[list[str]] = None,
     overwrite: bool = False,
-) -> None:  # pragma: no cover
+) -> str:  # pragma: no cover
     """Downloads dataset from Hugging Face Hub to local directory.
 
     Args:
@@ -300,7 +301,7 @@ def download_datasetdict_from_hub(
         overwrite (bool): Whether to overwrite existing directory.
 
     Returns:
-        None
+        str: Path to the local directory where the dataset has been downloaded.
     """
     output_folder = Path(local_dir)
 
@@ -315,7 +316,7 @@ def download_datasetdict_from_hub(
 
     allow_patterns, ignore_patterns = _zarr_patterns(repo_id, split_ids, features)
 
-    snapshot_download(
+    return snapshot_download(
         repo_id=repo_id,
         repo_type="dataset",
         allow_patterns=allow_patterns,


### PR DESCRIPTION
Only fixing a few type hints in the storage module

### Checklist

- [x] Typing enforced
- [ ] ~Documentation updated~
- [ ] ~Changelog updated~
- [ ] ~Tests and Example updates~
- [ ] ~Coverage should be 100%~
