### PR TITLE
🐛 fix(sample) get_global in the scalar case now returns the scalar with…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
+- (sample) get_global in the scalar case now returns the scalar with the original type.
 - (datasets) fix missing location use in get_field_names, and improve corresponding tests.
 - (cgns_helpers) update_features_for_CGNS_compatibility: fix behavior where input variable was modified by the function.
 - (storage/common/preprocessor) make constant_features split-dependant.

--- a/src/plaid/containers/features.py
+++ b/src/plaid/containers/features.py
@@ -751,11 +751,18 @@ class SampleFeatures:
             Optional[Array]: The global array if found, otherwise None. Returns a scalar if the array has size 1.
         """
         time = self.resolve_time(time)
-        if self.has_globals(time):
-            global_ = CGU.getValueByPath(self.data[time], "Global/" + name)
-            return global_.item() if getattr(global_, "size", None) == 1 else global_
-        else:
+
+        if not self.has_globals(time):
             return None
+
+        global_ = CGU.getValueByPath(self.data[time], "Global/" + name)
+        if global_ is None:
+            return None
+
+        if getattr(global_, "size", None) == 1:
+            return global_[0]
+
+        return global_
 
     def add_global(
         self,

--- a/tests/containers/test_sample.py
+++ b/tests/containers/test_sample.py
@@ -629,6 +629,7 @@ class Test_Sample:
     def test_get_scalar(self, sample_with_scalar):
         assert sample_with_scalar.get_scalar("missing_scalar_name") is None
         assert sample_with_scalar.get_scalar("test_scalar_1") is not None
+        assert isinstance(sample_with_scalar.get_scalar("test_scalar_1"), np.float64)
 
     def test_scalars_add_empty(self, sample_with_scalar):
         assert isinstance(sample_with_scalar.get_scalar("test_scalar_1"), float)


### PR DESCRIPTION
… the original type

### Checklist

- [ ] ~~Typing enforced~~
- [ ] ~~Documentation updated~~
- [x] Changelog updated
- [x] Tests and Example updates
- [x] Coverage should be 100%

### 🔗 Related issues (optional)

Closes #334 