### PR TITLE
:tada: Add functions to public API

### DIFF
--- a/src/plaid/__init__.py
+++ b/src/plaid/__init__.py
@@ -4,6 +4,17 @@ from .containers.sample import Sample
 from .containers.utils import get_number_of_samples, get_sample_ids
 from .infos import Infos
 from .problem_definition import ProblemDefinition
+from .storage import (
+    download_from_hub,
+    init_from_disk,
+    init_streaming_from_hub,
+    load_infos_from_disk,
+    load_infos_from_hub,
+    load_problem_definitions_from_disk,
+    load_problem_definitions_from_hub,
+    push_local_problem_definitions_to_hub,
+    save_problem_definitions_to_disk,
+)
 from .version import __version__
 
 __all__ = [
@@ -13,6 +24,15 @@ __all__ = [
     "Sample",
     "ProblemDefinition",
     "Infos",
+    "download_from_hub",
+    "init_from_disk",
+    "init_streaming_from_hub",
+    "load_infos_from_disk",
+    "load_infos_from_hub",
+    "load_problem_definitions_from_disk",
+    "load_problem_definitions_from_hub",
+    "push_local_problem_definitions_to_hub",
+    "save_problem_definitions_to_disk",
 ]
 
 import logging


### PR DESCRIPTION
Add a few functons to the public API. Example:

```python
from plaid import init_from_disk
```

instead of

```python
from plaid.storage import init_from_disk
```

### Checklist

- [x] Typing enforced
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Tests and Example updates
- [ ] Coverage should be 100%