### PR TITLE
🐛 Fix HF backend split download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- (storage/reader) Fix HF backend split download not respecting `~` character on Linux.
+
 ## [1.0.0] - 2026-07-07
 
 - This version introduces major modifications of the library.

--- a/src/plaid/storage/backend_api.py
+++ b/src/plaid/storage/backend_api.py
@@ -41,7 +41,7 @@ class BackendModule(Protocol):
         split_ids: Optional[dict[str, Iterable[int]]] = None,
         features: Optional[list[str]] = None,  # noqa: ARG001
         overwrite: bool = False,
-    ) -> str:
+    ) -> Path:
         """Download a dataset dictionary from a remote hub into a local folder."""
         ...
 

--- a/src/plaid/storage/cgns/__init__.py
+++ b/src/plaid/storage/cgns/__init__.py
@@ -33,7 +33,7 @@ class CgnsBackend:
         split_ids: Optional[dict[str, Iterable[int]]] = None,
         features: Optional[list[str]] = None,
         overwrite: bool = False,
-    ) -> str:
+    ) -> Path:
         return download_datasetdict_from_hub(
             repo_id=repo_id,
             local_dir=local_dir,

--- a/src/plaid/storage/cgns/reader.py
+++ b/src/plaid/storage/cgns/reader.py
@@ -191,7 +191,7 @@ def download_datasetdict_from_hub(
     split_ids: Optional[dict[str, Iterable[int]]] = None,
     features: Optional[list[str]] = None,  # noqa: ARG001
     overwrite: bool = False,
-) -> str:  # pragma: no cover
+) -> Path:  # pragma: no cover
     """Download a CGNS dataset from Hugging Face Hub to local disk.
 
     This function downloads selected parts or the entire CGNS dataset from a Hugging Face
@@ -220,11 +220,13 @@ def download_datasetdict_from_hub(
     else:
         allow_patterns = ["data/*"]
 
-    return snapshot_download(
-        repo_id=repo_id,
-        repo_type="dataset",
-        allow_patterns=allow_patterns,
-        local_dir=output_folder,
+    return Path(
+        snapshot_download(
+            repo_id=repo_id,
+            repo_type="dataset",
+            allow_patterns=allow_patterns,
+            local_dir=output_folder,
+        ),
     )
 
 

--- a/src/plaid/storage/cgns/reader.py
+++ b/src/plaid/storage/cgns/reader.py
@@ -13,7 +13,6 @@ Key features:
 
 import logging
 import os
-import shutil
 import tempfile
 from pathlib import Path
 from typing import Iterable, Iterator, Optional, Union
@@ -24,7 +23,10 @@ from datasets.splits import NamedSplit
 from huggingface_hub import snapshot_download
 
 from ...containers.sample import Sample
-from ..common.reader import load_infos_from_hub
+from ..common.reader import (
+    load_infos_from_hub,
+    prepare_local_folder_for_download,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -206,16 +208,10 @@ def download_datasetdict_from_hub(
     Returns:
         str: Path to the local directory where the dataset has been downloaded.
     """
-    output_folder = Path(local_dir)
-
-    if output_folder.is_dir():
-        if overwrite:
-            shutil.rmtree(local_dir)
-            logger.warning(f"Existing {local_dir} directory has been reset.")
-        elif any(output_folder.iterdir()):
-            raise ValueError(
-                f"directory {local_dir} already exists and is not empty. Set `overwrite` to True if needed."
-            )
+    output_folder = prepare_local_folder_for_download(
+        local_dir,
+        overwrite=overwrite,
+    )
 
     if split_ids is not None:
         allow_patterns = []
@@ -228,7 +224,7 @@ def download_datasetdict_from_hub(
         repo_id=repo_id,
         repo_type="dataset",
         allow_patterns=allow_patterns,
-        local_dir=local_dir,
+        local_dir=output_folder,
     )
 
 

--- a/src/plaid/storage/common/reader.py
+++ b/src/plaid/storage/common/reader.py
@@ -6,6 +6,7 @@ and other auxiliary files from disk or downloading them from Hugging Face Hub.
 
 import json
 import logging
+import shutil
 import tempfile
 from pathlib import Path
 from typing import Any, Optional, Union
@@ -306,3 +307,50 @@ def load_metadata_from_hub(
         cgns_types = yaml.safe_load(f)
 
     return flat_cst, variable_schema, constant_schema, cgns_types
+
+
+def _prepare_local_folder_on_disk(
+    output_folder: Path,
+    *,
+    overwrite: bool,
+) -> None:  # pragma: no cover
+    if overwrite:
+        shutil.rmtree(output_folder)
+        logger.warning(
+            "Existing %s directory has been reset.",
+            output_folder,
+        )
+    elif any(output_folder.iterdir()):
+        raise ValueError(
+            f"directory {output_folder} already exists and is not empty. "
+            "Set `overwrite` to True if needed."
+        )
+
+
+def prepare_local_folder_for_download(
+    output_folder: Path | str,
+    *,
+    overwrite: bool,
+) -> Path:
+    """Prepare local folder for dataset download.
+
+    Checks if folder is not empty and overwrite is not set to true raises
+    ValueError.
+
+    Args:
+        output_folder (Path): Path to folder to prepare.
+        overwrite (bool): Whether to overwrite existing folder.
+
+    Returns:
+        Path: Path to output folder, with simlink resolved and user dir
+              expanded.
+    """
+    output_folder = Path(output_folder).expanduser()
+
+    if output_folder.is_dir():
+        _prepare_local_folder_on_disk(  # pragma: no cover
+            output_folder,
+            overwrite=overwrite,
+        )
+
+    return output_folder

--- a/src/plaid/storage/hf_datasets/__init__.py
+++ b/src/plaid/storage/hf_datasets/__init__.py
@@ -38,7 +38,7 @@ class HFBackend:
         split_ids: Optional[dict[str, Iterable[int]]] = None,
         features: Optional[list[str]] = None,  # noqa: ARG001
         overwrite: bool = False,
-    ) -> str:
+    ) -> Path:
         return download_datasetdict_from_hub(
             repo_id=repo_id,
             local_dir=local_dir,

--- a/src/plaid/storage/hf_datasets/reader.py
+++ b/src/plaid/storage/hf_datasets/reader.py
@@ -82,7 +82,7 @@ def download_datasetdict_from_hub(
     split_ids: Optional[dict[str, Iterable[int]]] = None,  # noqa: ARG001
     features: Optional[list[str]] = None,  # noqa: ARG001
     overwrite: bool = False,
-) -> str:
+) -> Path:
     """Downloads a dataset from Hugging Face Hub to local directory.
 
     Args:
@@ -113,7 +113,7 @@ def download_datasetdict_from_hub(
             output_folder=output_folder,
         )
 
-    return str(output_folder)
+    return output_folder
 
 
 def init_datasetdict_streaming_from_hub(

--- a/src/plaid/storage/hf_datasets/reader.py
+++ b/src/plaid/storage/hf_datasets/reader.py
@@ -13,7 +13,6 @@
 
 import logging
 import os
-import shutil
 import tempfile
 from pathlib import Path
 from typing import Any, Iterable, Optional, Union
@@ -22,7 +21,10 @@ import datasets
 from datasets import load_dataset, load_from_disk
 from huggingface_hub import snapshot_download
 
-from plaid.storage.common.reader import load_infos_from_hub
+from plaid.storage.common.reader import (
+    load_infos_from_hub,
+    prepare_local_folder_for_download,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -56,13 +58,31 @@ def init_datasetdict_from_disk(path: Union[str, Path]) -> HFDatasetDict:
 # ------------------------------------------------------
 
 
+def _split_download(
+    *,
+    repo_id: str,
+    tmp_dir: str,
+    output_folder: Path,
+) -> None:  # pragma: no cover
+    infos = load_infos_from_hub(repo_id=repo_id)
+    split_names = list(infos.num_samples.keys())
+    base = Path(tmp_dir) / "data"
+    data_files = {sn: str(base / f"{sn}*.parquet") for sn in split_names}
+    datasetdict = load_dataset(
+        "parquet",
+        data_files=data_files,
+        cache_dir=tmp_dir,
+    )
+    datasetdict.save_to_disk(Path(output_folder) / "data")
+
+
 def download_datasetdict_from_hub(
     repo_id: str,
     local_dir: Union[str, Path],
     split_ids: Optional[dict[str, Iterable[int]]] = None,  # noqa: ARG001
     features: Optional[list[str]] = None,  # noqa: ARG001
     overwrite: bool = False,
-) -> str:  # pragma: no cover (not tested in unit tests)
+) -> str:
     """Downloads a dataset from Hugging Face Hub to local directory.
 
     Args:
@@ -75,16 +95,10 @@ def download_datasetdict_from_hub(
     Returns:
         str: Path to the downloaded dataset.
     """
-    output_folder = Path(local_dir)
-
-    if output_folder.is_dir():
-        if overwrite:
-            shutil.rmtree(output_folder)
-            logger.warning(f"Existing {output_folder} directory has been reset.")
-        elif any(output_folder.iterdir()):
-            raise ValueError(
-                f"directory {output_folder} already exists and is not empty. Set `overwrite` to True if needed."
-            )
+    output_folder = prepare_local_folder_for_download(
+        local_dir,
+        overwrite=overwrite,
+    )
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         snapshot_download(
@@ -93,12 +107,11 @@ def download_datasetdict_from_hub(
             allow_patterns=["data/*"],
             local_dir=tmp_dir,
         )
-        infos = load_infos_from_hub(repo_id=repo_id)
-        split_names = list(infos.num_samples.keys())
-        base = Path(tmp_dir) / "data"
-        data_files = {sn: str(base / f"{sn}*.parquet") for sn in split_names}
-        datasetdict = load_dataset("parquet", data_files=data_files, cache_dir=tmp_dir)
-        datasetdict.save_to_disk(str(Path(output_folder) / "data"))
+        _split_download(
+            repo_id=repo_id,
+            tmp_dir=tmp_dir,
+            output_folder=output_folder,
+        )
 
     return str(output_folder)
 

--- a/src/plaid/storage/reader.py
+++ b/src/plaid/storage/reader.py
@@ -302,18 +302,28 @@ def download_from_hub(
     backend = infos.storage_backend
 
     backend_spec = get_backend(backend)
-    backend_spec.download_from_hub(repo_id, local_dir, split_ids, features, overwrite)
+    output_dir = backend_spec.download_from_hub(
+        repo_id,
+        local_dir,
+        split_ids,
+        features,
+        overwrite,
+    )
 
     if backend != "cgns":
         flat_cst, variable_schema, constant_schema, cgns_types = load_metadata_from_hub(
             repo_id
         )
         save_metadata_to_disk(
-            local_dir, flat_cst, variable_schema, constant_schema, cgns_types
+            output_dir,
+            flat_cst,
+            variable_schema,
+            constant_schema,
+            cgns_types,
         )
-    save_infos_to_disk(local_dir, infos)
+    save_infos_to_disk(output_dir, infos)
     if pb_defs is not None:
-        save_problem_definitions_to_disk(local_dir, pb_defs)
+        save_problem_definitions_to_disk(output_dir, pb_defs)
 
 
 def init_streaming_from_hub(

--- a/src/plaid/storage/reader.py
+++ b/src/plaid/storage/reader.py
@@ -301,6 +301,9 @@ def download_from_hub(
 
     backend = infos.storage_backend
 
+    if backend is None:
+        raise ValueError("Could not determine backend from info.")
+
     backend_spec = get_backend(backend)
     output_dir = backend_spec.download_from_hub(
         repo_id,

--- a/src/plaid/storage/zarr/__init__.py
+++ b/src/plaid/storage/zarr/__init__.py
@@ -39,7 +39,7 @@ class ZarrBackend:
         split_ids: Optional[dict[str, Iterable[int]]] = None,
         features: Optional[list[str]] = None,
         overwrite: bool = False,
-    ) -> str:
+    ) -> Path:
         return download_datasetdict_from_hub(
             repo_id=repo_id,
             local_dir=local_dir,

--- a/src/plaid/storage/zarr/reader.py
+++ b/src/plaid/storage/zarr/reader.py
@@ -243,7 +243,7 @@ def download_datasetdict_from_hub(
     split_ids: Optional[dict[str, Iterable[int]]] = None,
     features: Optional[list[str]] = None,
     overwrite: bool = False,
-) -> str:  # pragma: no cover
+) -> Path:  # pragma: no cover
     """Downloads dataset from Hugging Face Hub to local directory.
 
     Args:
@@ -263,12 +263,14 @@ def download_datasetdict_from_hub(
 
     allow_patterns, ignore_patterns = _zarr_patterns(repo_id, split_ids, features)
 
-    return snapshot_download(
-        repo_id=repo_id,
-        repo_type="dataset",
-        allow_patterns=allow_patterns,
-        ignore_patterns=ignore_patterns,
-        local_dir=output_folder,
+    return Path(
+        snapshot_download(
+            repo_id=repo_id,
+            repo_type="dataset",
+            allow_patterns=allow_patterns,
+            ignore_patterns=ignore_patterns,
+            local_dir=output_folder,
+        ),
     )
 
 

--- a/src/plaid/storage/zarr/reader.py
+++ b/src/plaid/storage/zarr/reader.py
@@ -14,7 +14,6 @@ Key features:
 
 import logging
 import os
-import shutil
 from pathlib import Path
 from typing import Any, Iterable, Iterator, Optional, Union
 
@@ -26,7 +25,10 @@ from datasets.splits import NamedSplit
 from huggingface_hub import hf_hub_download, snapshot_download
 
 from plaid.storage.common.bridge import flatten_path, unflatten_path
-from plaid.storage.common.reader import load_infos_from_hub
+from plaid.storage.common.reader import (
+    load_infos_from_hub,
+    prepare_local_folder_for_download,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -254,16 +256,10 @@ def download_datasetdict_from_hub(
     Returns:
         str: Path to the local directory where the dataset has been downloaded.
     """
-    output_folder = Path(local_dir)
-
-    if output_folder.is_dir():
-        if overwrite:
-            shutil.rmtree(local_dir)
-            logger.warning(f"Existing {local_dir} directory has been reset.")
-        elif any(local_dir.iterdir()):
-            raise ValueError(
-                f"directory {local_dir} already exists and is not empty. Set `overwrite` to True if needed."
-            )
+    output_folder = prepare_local_folder_for_download(
+        local_dir,
+        overwrite=overwrite,
+    )
 
     allow_patterns, ignore_patterns = _zarr_patterns(repo_id, split_ids, features)
 
@@ -272,7 +268,7 @@ def download_datasetdict_from_hub(
         repo_type="dataset",
         allow_patterns=allow_patterns,
         ignore_patterns=ignore_patterns,
-        local_dir=local_dir,
+        local_dir=output_folder,
     )
 
 

--- a/tests/storage/test_hf_datasets_reader.py
+++ b/tests/storage/test_hf_datasets_reader.py
@@ -63,4 +63,4 @@ def test_hf_datasets_download_datasetdict_split_download(
     for key, value in expected.items():
         assert call_kwargs[key] == value
 
-    assert result == str(expected["output_folder"])
+    assert result == expected["output_folder"]

--- a/tests/storage/test_hf_datasets_reader.py
+++ b/tests/storage/test_hf_datasets_reader.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+import plaid.storage.common.reader as common_reader
+import plaid.storage.hf_datasets.reader as hf_datasets_reader
+
+
+@pytest.mark.parametrize(
+    "arguments,expected",
+    [
+        pytest.param(
+            {
+                "repo_id": "dummy/repo",
+                "local_dir": "/tmp/local",
+            },
+            {
+                "output_folder": Path("/tmp/local"),
+            },
+            id="Absolute path",
+        ),
+        pytest.param(
+            {
+                "repo_id": "dummy/repo",
+                "local_dir": "~/local",
+            },
+            {
+                "output_folder": Path("~/local").expanduser(),
+            },
+            id="Path contains user dir",
+        ),
+    ],
+)
+def test_hf_datasets_download_datasetdict_split_download(
+    monkeypatch,
+    arguments,
+    expected,
+):
+    fake__split_download = Mock()
+
+    monkeypatch.setattr(
+        common_reader,
+        "_prepare_local_folder_on_disk",
+        lambda *_, **__: None,
+    )
+    monkeypatch.setattr(
+        hf_datasets_reader,
+        "snapshot_download",
+        lambda *_, **__: None,
+    )
+    monkeypatch.setattr(
+        hf_datasets_reader,
+        "_split_download",
+        fake__split_download,
+    )
+
+    result = hf_datasets_reader.download_datasetdict_from_hub(**arguments)
+
+    fake__split_download.assert_called_once()
+    call_kwargs = fake__split_download.call_args.kwargs
+
+    for key, value in expected.items():
+        assert call_kwargs[key] == value
+
+    assert result == str(expected["output_folder"])


### PR DESCRIPTION
Thanks for contributing! Please make sure your PR title and content follow the guidelines.
Leave this checklist below in your PR description and tick the corresponding boxes.

### Checklist

- [ x] Typing enforced
- [ x] Documentation updated
- [ x] Changelog updated
- [ x] Tests and Example updates
- [ x] Coverage should be 100%

---

### 📋 Description (optional)

Fix dataset download from hub for HF backend.
The split download mechanism did not respect the `~` character on Linux.

This also bundles two supplementary commits:
- Change the return type of `BackendModule.download_from_hub`
- Add a sanity check for backend in `plaid.storage.download_from_hub`

---

Closes #474 