### PR TITLE
🐛 resolve get_physical_dim across multiple bases when unambiguous

### DIFF
--- a/src/plaid/containers/managers/default_manager.py
+++ b/src/plaid/containers/managers/default_manager.py
@@ -150,6 +150,15 @@ class DefaultManager:
             raise ValueError(f"base {base} does not exist at time {time}")
         self._default_active_base = base
 
+    def get_default_base(self) -> Optional[str]:
+        """Return the currently set default active base, if any.
+
+        Returns:
+            Optional[str]: The default active base name, or ``None`` if no default
+            base has been set.
+        """
+        return self._default_active_base
+
     def set_default_zone_base(
         self, zone: str, base: str, time: Optional[float] = None
     ) -> None:

--- a/src/plaid/containers/sample.py
+++ b/src/plaid/containers/sample.py
@@ -747,14 +747,19 @@ class Sample(BaseModel, arbitrary_types_allowed=True, extra="forbid"):
         Returns:
             int: The physical dimension of the specified base node at the given time.
         """
-        # When no base is specified and several exist, the physical dimension may still
-        # be unambiguous: it is a per-base CGNS attribute, but bases often share it.
-        # (resolve_base would raise on >1 base without a default, so we check directly.)
+        # When no base is specified, defer to the usual base resolution: an explicit
+        # base or a default base is honoured, and a single base needs no default.
+        # resolve_base only raises when several bases exist and none is set as default.
+        # In that ambiguous case the physical dimension may still be well-defined,
+        # because it is a per-base CGNS attribute that bases usually share: return the
+        # common value if all bases agree, and only raise if they genuinely differ.
         if base is None:
-            base_names = self.get_base_names(time=time)
-            if "Global" in base_names:
-                base_names.remove("Global")
-            if len(base_names) > 1:
+            try:
+                base = self.resolve_base(base, time)
+            except KeyError:
+                base_names = self.get_base_names(time=time)
+                if "Global" in base_names:
+                    base_names.remove("Global")
                 phys_dims = {
                     int(self.get_base(b, time)[1][1])  # type: ignore[index]
                     for b in base_names
@@ -765,7 +770,7 @@ class Sample(BaseModel, arbitrary_types_allowed=True, extra="forbid"):
                     "Cannot resolve the physical dimension: bases have differing "
                     f"physical dimensions {sorted(phys_dims)} among {base_names}. "
                     "Specify a base explicitly."
-                )
+                ) from None
 
         base_node = self.get_base(base, time)
         if base_node is None:  # pragma: no cover

--- a/src/plaid/containers/sample.py
+++ b/src/plaid/containers/sample.py
@@ -477,6 +477,15 @@ class Sample(BaseModel, arbitrary_types_allowed=True, extra="forbid"):
         """
         self.defaults.set_default_base(base, time=time)
 
+    def get_default_base(self) -> Optional[str]:
+        """Get the default active base. Calls the DefaultManager to get the default base.
+
+        Returns:
+            Optional[str]: The default active base name, or ``None`` if no default
+            base has been set.
+        """
+        return self.defaults.get_default_base()
+
     def set_default_zone_base(
         self, zone: str, base: str, time: Optional[float] = None
     ) -> None:
@@ -747,19 +756,17 @@ class Sample(BaseModel, arbitrary_types_allowed=True, extra="forbid"):
         Returns:
             int: The physical dimension of the specified base node at the given time.
         """
-        # When no base is specified, defer to the usual base resolution: an explicit
-        # base or a default base is honoured, and a single base needs no default.
-        # resolve_base only raises when several bases exist and none is set as default.
-        # In that ambiguous case the physical dimension may still be well-defined,
-        # because it is a per-base CGNS attribute that bases usually share: return the
-        # common value if all bases agree, and only raise if they genuinely differ.
+        # When no base is specified, the physical dimension is usually still
+        # well-defined even if several bases exist: it is a per-base CGNS attribute,
+        # but bases typically share it. Branch explicitly on the resolution cases:
+        #   - an explicit or default base, or a single base, is unambiguous;
+        #   - several bases without a default are only ambiguous if their physical
+        #     dimensions actually differ, in which case we raise.
         if base is None:
-            try:
-                base = self.resolve_base(base, time)
-            except KeyError:
-                base_names = self.get_base_names(time=time)
-                if "Global" in base_names:
-                    base_names.remove("Global")
+            base_names = self.get_base_names(time=time)
+            if "Global" in base_names:
+                base_names.remove("Global")
+            if len(base_names) > 1 and self.get_default_base() is None:
                 phys_dims = {
                     int(self.get_base(b, time)[1][1])  # type: ignore[index]
                     for b in base_names
@@ -770,7 +777,9 @@ class Sample(BaseModel, arbitrary_types_allowed=True, extra="forbid"):
                     "Cannot resolve the physical dimension: bases have differing "
                     f"physical dimensions {sorted(phys_dims)} among {base_names}. "
                     "Specify a base explicitly."
-                ) from None
+                )
+            # 0 or 1 base, or a default base is set: resolution is unambiguous.
+            base = self.resolve_base(base, time)
 
         base_node = self.get_base(base, time)
         if base_node is None:  # pragma: no cover

--- a/src/plaid/containers/sample.py
+++ b/src/plaid/containers/sample.py
@@ -656,7 +656,7 @@ class Sample(BaseModel, arbitrary_types_allowed=True, extra="forbid"):
         elif time not in self.data:
             self.data[time] = tree
         else:
-            # TODO: gérer le cas où il y a des bases de mêmes noms... + merge
+            # TODO: gérer le cas où il y a des bases de mêmes noms... + merge
             # récursif des nœuds
             local_bases = self.get_base_names(time=time)
             base_nodes = CGU.getNodesFromTypeSet(tree, "CGNSBase_t")
@@ -731,16 +731,42 @@ class Sample(BaseModel, arbitrary_types_allowed=True, extra="forbid"):
     ) -> int:
         """Get the physical dimension of a base node at a specific time.
 
+        Unlike the topological dimension, when no ``base`` is given and several bases
+        exist, this does not require a default base as long as all bases share the same
+        physical dimension: the common value is returned. If the physical dimensions
+        differ across bases, the ambiguity is real and a ``ValueError`` is raised asking
+        the caller to specify a base.
+
         Args:
-            base (str, optional): The name of the base node for which to retrieve the topological dimension. Defaults to None.
-            time (float, optional): The time at which to retrieve the topological dimension. Defaults to None.
+            base (str, optional): The name of the base node for which to retrieve the physical dimension. Defaults to None.
+            time (float, optional): The time at which to retrieve the physical dimension. Defaults to None.
 
         Raises:
-            ValueError: If there is no base node with the specified `base` at the given `time` in this sample.
+            ValueError: If there is no base node with the specified `base` at the given `time` in this sample, or if no base is specified and bases have differing physical dimensions.
 
         Returns:
-            int: The topological dimension of the specified base node at the given time.
+            int: The physical dimension of the specified base node at the given time.
         """
+        # When no base is specified and several exist, the physical dimension may still
+        # be unambiguous: it is a per-base CGNS attribute, but bases often share it.
+        # (resolve_base would raise on >1 base without a default, so we check directly.)
+        if base is None:
+            base_names = self.get_base_names(time=time)
+            if "Global" in base_names:
+                base_names.remove("Global")
+            if len(base_names) > 1:
+                phys_dims = {
+                    int(self.get_base(b, time)[1][1])  # type: ignore[index]
+                    for b in base_names
+                }
+                if len(phys_dims) == 1:
+                    return phys_dims.pop()
+                raise ValueError(
+                    "Cannot resolve the physical dimension: bases have differing "
+                    f"physical dimensions {sorted(phys_dims)} among {base_names}. "
+                    "Specify a base explicitly."
+                )
+
         base_node = self.get_base(base, time)
         if base_node is None:  # pragma: no cover
             raise ValueError(

--- a/tests/containers/test_sample.py
+++ b/tests/containers/test_sample.py
@@ -503,6 +503,10 @@ class Test_Sample:
         sample.init_base(2, 3, "base_a")
         sample.init_base(3, 3, "base_b")
         assert sample.get_physical_dim() == 3
+        # The "Global" base is a special container and must be ignored when checking
+        # for a common physical dimension.
+        sample.add_global("scalar", 1.0)
+        assert sample.get_physical_dim() == 3
         # The topological dimension is still ambiguous and must fail without a base.
         with pytest.raises(KeyError):
             sample.get_topological_dim()

--- a/tests/containers/test_sample.py
+++ b/tests/containers/test_sample.py
@@ -521,6 +521,16 @@ class Test_Sample:
         assert sample.get_physical_dim("line") == 1
         assert sample.get_physical_dim("volume") == 3
 
+    def test_get_physical_dim_multibase_diverging_default_base(self, sample: Sample):
+        # A default base is honoured even when physical dimensions diverge: the
+        # explicit branch must not treat the diverging case as ambiguous.
+        sample.init_base(1, 1, "line")
+        sample.init_base(3, 3, "volume")
+        sample.set_default_base("volume")
+        assert sample.get_physical_dim() == 3
+        sample.set_default_base("line")
+        assert sample.get_physical_dim() == 1
+
     # -------------------------------------------------------------------------#
     def test_init_zone(self, sample: Sample, base_name, zone_name, zone_shape):
         with pytest.raises(KeyError):

--- a/tests/containers/test_sample.py
+++ b/tests/containers/test_sample.py
@@ -498,6 +498,25 @@ class Test_Sample:
         assert sample.get_topological_dim("other_base_name") == 3
         assert sample.get_physical_dim("other_base_name") == 3
 
+    def test_get_physical_dim_multibase(self, sample: Sample):
+        # Several bases sharing the same physical dimension: no default base needed.
+        sample.init_base(2, 3, "base_a")
+        sample.init_base(3, 3, "base_b")
+        assert sample.get_physical_dim() == 3
+        # The topological dimension is still ambiguous and must fail without a base.
+        with pytest.raises(KeyError):
+            sample.get_topological_dim()
+
+    def test_get_physical_dim_multibase_diverging(self, sample: Sample):
+        # Bases with differing physical dimensions: the ambiguity is real.
+        sample.init_base(1, 1, "line")
+        sample.init_base(3, 3, "volume")
+        with pytest.raises(ValueError, match="differing"):
+            sample.get_physical_dim()
+        # Specifying a base resolves it.
+        assert sample.get_physical_dim("line") == 1
+        assert sample.get_physical_dim("volume") == 3
+
     # -------------------------------------------------------------------------#
     def test_init_zone(self, sample: Sample, base_name, zone_name, zone_shape):
         with pytest.raises(KeyError):


### PR DESCRIPTION
## Context

Fixes #482.

`Sample.get_physical_dim()` currently delegates base resolution to `resolve_base()`, which raises as soon as a Sample holds more than one base and no default base is set. This forces callers to set a default base even when the answer is unambiguous.

The physical dimension is stored **per base** in the CGNS datamodel (the 2nd integer of the `CGNSBase_t` node value, set by `newCGNSBase` in `init_base`), and nothing constrains different bases to agree. However, in the overwhelming majority of real Samples all bases *do* share the same physical dimension (e.g. a volume base and its surface/line boundary bases all live in the same ambient space). So requiring a default base in that case is unnecessary friction.

## Change

`get_physical_dim(base=None)` now:

- collects the physical dimension of every base (ignoring the special `Global` base);
- returns the common value when all bases agree — **no default base needed**;
- raises a clear `ValueError` asking the caller to specify a base **only** when the physical dimensions actually differ across bases.

Passing an explicit `base` keeps the previous behaviour unchanged. `get_topological_dim()` is intentionally left as-is: topological dimensions legitimately differ between bases (a 3D volume base vs. a 2D surface base), so the ambiguity there is real.

This is backward compatible: previously-working calls keep working, and calls that used to raise on multi-base Samples now succeed when the value is unambiguous.

## Tests

Added `test_get_physical_dim_multibase` (agreeing bases → common value returned, topological dim still raises) and `test_get_physical_dim_multibase_diverging` (differing bases → explicit `ValueError`, explicit base resolves it).