### PR TITLE
📄 Add Args/Returns/Raises sections to core public API docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - (storage/writer) add optional `sample_callback` to `save_to_disk`, invoked once per sample right after it is written to disk as `sample_callback(split_name, index, sample_path)`. This lets callers process samples one by one once written instead of waiting for the whole dataset. Currently supported for the `cgns` backend, including parallel writing (`num_proc > 1`), where the callback runs inside the worker processes and must be picklable and process-safe.
 
+- (docs) add `Args`/`Returns`/`Raises` sections to the docstrings of core public APIs whose summaries previously stated only the behaviour: the storage backend protocol methods (`storage.backend_api.BackendModule`), the `Infos` validation classmethods (`infos.Infos`), the default-manager feature protocol (`containers.managers.default_manager.FeaturesBackend`), plus `storage.registry.get_backend`, `containers.utils.get_feature_details_from_path`, and `storage.common.preprocessor.infer_dtype`.
+
 ### Fixed
 
 - (storage/reader) Fix HF backend split download not respecting `~` character on Linux.

--- a/src/plaid/containers/managers/default_manager.py
+++ b/src/plaid/containers/managers/default_manager.py
@@ -27,11 +27,30 @@ class FeaturesBackend(Protocol):
     def get_zone_names(
         self, base: Optional[str] = None, *, time: Optional[float] = None
     ) -> list[str]:
-        """Get all available zone names within a base at a given time."""
+        """Get all available zone names within a base at a given time.
+
+        Args:
+            base (str, optional): The name of the base to inspect. If not
+                provided, the default base is used.
+            time (float, optional): The time at which zones are looked up. If
+                not provided, the default time is used.
+
+        Returns:
+            list[str]: The names of the available zones.
+        """
         ...
 
     def has_base(self, base: str, time: Optional[float] = None) -> bool:
-        """Check if a base exists at a given time."""
+        """Check if a base exists at a given time.
+
+        Args:
+            base (str): The name of the base to look up.
+            time (float, optional): The time at which the base is looked up.
+                If not provided, the default time is used.
+
+        Returns:
+            bool: True if the base exists at the given time.
+        """
         ...
 
     def has_zone(
@@ -40,7 +59,18 @@ class FeaturesBackend(Protocol):
         base: Optional[str] = None,
         time: Optional[float] = None,
     ) -> bool:
-        """Check if a zone exists within a base at a given time."""
+        """Check if a zone exists within a base at a given time.
+
+        Args:
+            zone (str): The name of the zone to look up.
+            base (str, optional): The name of the base containing the zone. If
+                not provided, the default base is used.
+            time (float, optional): The time at which the zone is looked up.
+                If not provided, the default time is used.
+
+        Returns:
+            bool: True if the zone exists within the base at the given time.
+        """
         ...
 
 

--- a/src/plaid/containers/utils.py
+++ b/src/plaid/containers/utils.py
@@ -146,7 +146,17 @@ def get_number_of_samples(savedir: Union[str, Path]) -> int:
 
 
 def get_feature_details_from_path(path: str) -> dict[str, str]:
-    """Retrieve semantic details from a CGNS-style path."""
+    """Retrieve semantic details from a CGNS-style path.
+
+    Args:
+        path (str): The CGNS-style path to parse, e.g.
+            ``Base_2/Zone_1/GridCoordinates``.
+
+    Returns:
+        dict[str, str]: The parsed details, including ``type``, ``sub_type``,
+            and, depending on the path, ``base``, ``zone``, ``name``, and
+            ``element_type``.
+    """
     split_path = path.split("/")
     feat: dict[str, str] = {}
 

--- a/src/plaid/infos.py
+++ b/src/plaid/infos.py
@@ -104,7 +104,19 @@ class Infos(
 
     @classmethod
     def validate_authorized_only(cls, infos: dict[str, Any]) -> "Infos":
-        """Validate schema/authorized keys without enforcing required sections."""
+        """Validate schema/authorized keys without enforcing required sections.
+
+        Args:
+            infos: Raw infos mapping to validate.
+
+        Returns:
+            Validated :class:`Infos` instance; required sections that are
+                missing from ``infos`` are filled in with empty defaults.
+
+        Raises:
+            KeyError: If ``infos`` contains keys that are not authorized by the
+                schema.
+        """
         normalized = dict(infos)
         had_owner = "owner" in normalized
         had_license = "license" in normalized
@@ -142,17 +154,43 @@ class Infos(
 
     @classmethod
     def validate_required_only(cls, infos: dict[str, Any]) -> None:
-        """Validate entries required for persisted dataset infos."""
+        """Validate entries required for persisted dataset infos.
+
+        Args:
+            infos: Raw infos mapping to validate.
+
+        Raises:
+            ValueError: If a field required for persisted infos
+                (``num_samples`` or ``storage_backend``) is missing.
+        """
         cls.model_validate(infos).require_persisted()
 
     @classmethod
     def validate_persisted(cls, infos: dict[str, Any]) -> "Infos":
-        """Validate and return complete infos loaded from persisted storage."""
+        """Validate and return complete infos loaded from persisted storage.
+
+        Args:
+            infos: Raw infos mapping loaded from persisted storage.
+
+        Returns:
+            Validated :class:`Infos` instance.
+
+        Raises:
+            ValueError: If a field required for persisted infos
+                (``num_samples`` or ``storage_backend``) is missing.
+        """
         return cls.model_validate(infos).require_persisted()
 
     @classmethod
     def normalize_mapping(cls, infos: dict[str, Any]) -> dict[str, Any]:
-        """Validate and return a normalized deep copy of infos."""
+        """Validate and return a normalized deep copy of infos.
+
+        Args:
+            infos: Raw infos mapping to validate.
+
+        Returns:
+            Normalized deep copy of the infos with ``None`` values excluded.
+        """
         model = cls.model_validate(infos)
         return model.model_dump(exclude_none=True)
 

--- a/src/plaid/storage/backend_api.py
+++ b/src/plaid/storage/backend_api.py
@@ -33,7 +33,14 @@ class BackendModule(Protocol):
 
     @staticmethod
     def init_from_disk(path: Union[str, Path]) -> Mapping[str, Any]:
-        """Load a dataset dictionary from local storage."""
+        """Load a dataset dictionary from local storage.
+
+        Args:
+            path (Union[str, Path]): Path to the local dataset directory.
+
+        Returns:
+            Mapping[str, Any]: The loaded dataset dictionary.
+        """
         ...
 
     @staticmethod
@@ -44,7 +51,21 @@ class BackendModule(Protocol):
         features: Optional[list[str]] = None,  # noqa: ARG001
         overwrite: bool = False,
     ) -> Path:
-        """Download a dataset dictionary from a remote hub into a local folder."""
+        """Download a dataset dictionary from a remote hub into a local folder.
+
+        Args:
+            repo_id (str): The repository ID on the remote hub.
+            local_dir (Union[str, Path]): Local directory the dataset is
+                downloaded into.
+            split_ids (Optional[dict[str, Iterable[int]]]): Optional mapping of
+                split names to the sample indices to download.
+            features (Optional[list[str]]): Optional list of features to
+                restrict the download to.
+            overwrite (bool): Whether to overwrite an existing local directory.
+
+        Returns:
+            Path: The path to the downloaded dataset directory.
+        """
         ...
 
     @staticmethod
@@ -53,7 +74,18 @@ class BackendModule(Protocol):
         split_ids: Optional[dict[str, Iterable[int]]] = None,
         features: Optional[list[str]] = None,  # noqa: ARG001
     ) -> dict[str, IterableDataset]:
-        """Initialize a streaming dataset dictionary from a remote hub."""
+        """Initialize a streaming dataset dictionary from a remote hub.
+
+        Args:
+            repo_id (str): The repository ID on the remote hub.
+            split_ids (Optional[dict[str, Iterable[int]]]): Optional mapping of
+                split names to the sample indices to include in the stream.
+            features (Optional[list[str]]): Optional list of features to load.
+
+        Returns:
+            dict[str, IterableDataset]: The streaming dataset dictionary,
+                keyed by split name.
+        """
         ...
 
     @staticmethod
@@ -70,6 +102,22 @@ class BackendModule(Protocol):
         """Generate and save a dataset dictionary to local storage.
 
         ``sample_callback`` is called after each CGNS sample is written.
+
+        Args:
+            output_folder (Union[str, Path]): Directory the dataset is written
+                into.
+            generators (dict[str, Callable[..., Generator]]): Mapping of split
+                names to sample generator callables.
+            variable_schema (Optional[dict[str, dict]]): Optional schema
+                describing the variable features of the dataset.
+            gen_kwargs (Optional[dict[str, dict[str, Any]]]): Optional keyword
+                arguments passed to each generator, keyed by split name.
+            num_proc (int): Number of worker processes used to write samples.
+            verbose (bool): Whether to display progress information.
+            sample_callback (Optional[SampleCallback]): Callback invoked once
+                per sample right after it is written to disk.
+            worker_initializer (Optional[Callable[[], None]]): Optional
+                callable run once in each worker process before generation.
         """
         ...
 
@@ -77,7 +125,13 @@ class BackendModule(Protocol):
     def push_local_to_hub(
         repo_id: str, local_dir: Union[str, Path], num_workers: int = 1
     ) -> None:
-        """Push a local dataset dictionary to a remote hub repository."""
+        """Push a local dataset dictionary to a remote hub repository.
+
+        Args:
+            repo_id (str): The repository ID on the remote hub.
+            local_dir (Union[str, Path]): Local dataset directory to push.
+            num_workers (int): Number of workers used for uploading.
+        """
         ...
 
     @staticmethod
@@ -91,7 +145,25 @@ class BackendModule(Protocol):
         illustration_urls: Optional[list[str]] = None,
         arxiv_paper_urls: Optional[list[str]] = None,
     ) -> None:  # pragma: no cover
-        """Configure metadata for a dataset card associated with a repository."""
+        """Configure metadata for a dataset card associated with a repository.
+
+        Args:
+            repo_id (str): The repository ID the dataset card is associated
+                with.
+            infos (Infos): Dataset metadata, including legal information such
+                as the license.
+            local_dir (Optional[Union[str, Path]]): Optional local directory
+                holding the dataset being described.
+            viewer (bool): Whether to enable the dataset viewer. Defaults to
+                False.
+            pretty_name (Optional[str]): A human-readable name for the dataset.
+            dataset_long_description (Optional[str]): A detailed description of
+                the dataset.
+            illustration_urls (Optional[list[str]]): List of URLs to images
+                illustrating the dataset.
+            arxiv_paper_urls (Optional[list[str]]): List of arXiv URLs for
+                papers related to the dataset.
+        """
         ...
 
     @staticmethod
@@ -101,12 +173,32 @@ class BackendModule(Protocol):
         features: Optional[list[str]] = None,
         indexers: Optional[dict[str, Any]] = None,
     ) -> dict[str, Optional[np.ndarray]]:
-        """Convert a backend sample to PLAID variable-sample dictionary representation."""
+        """Convert a backend sample to PLAID variable-sample dictionary representation.
+
+        Args:
+            dataset (Dataset): The dataset to convert.
+            idx (int): The sample index.
+            features (Optional[list[str]]): Optional list of feature names to
+                extract from the dataset.
+            indexers (Optional[dict[str, Any]]): Optional mapping
+                ``feature_path -> indexer`` used to select feature values along
+                the last axis.
+
+        Returns:
+            dict[str, Optional[np.ndarray]]: The variable sample dictionary.
+        """
         ...
 
     @staticmethod
     def sample_to_var_sample_dict(
         sample: dict[str, Any],
     ) -> dict[str, Any]:
-        """Convert a backend-native sample object to a variable-sample dictionary."""
+        """Convert a backend-native sample object to a variable-sample dictionary.
+
+        Args:
+            sample (dict[str, Any]): The backend-native sample dictionary.
+
+        Returns:
+            dict[str, Any]: The variable sample dictionary.
+        """
         ...

--- a/src/plaid/storage/common/preprocessor.py
+++ b/src/plaid/storage/common/preprocessor.py
@@ -22,7 +22,22 @@ logger = logging.getLogger(__name__)
 
 
 def infer_dtype(value: Any) -> dict[str, int | str]:
-    """Infer canonical dtype schema from a value."""
+    """Infer canonical dtype schema from a value.
+
+    Args:
+        value (Any): The value to inspect; either ``None`` or an array-like
+            (list, tuple, or numpy array).
+
+    Returns:
+        dict[str, int | str]: The inferred schema, with the canonical
+            ``dtype`` name (e.g. ``float32``, ``int32``, ``int64``,
+            ``string``, ``S1``, or ``null``) and the array ``ndim``.
+
+    Raises:
+        ValueError: If the value is a scalar (CGNS should return arrays) or
+            has an unrecognized dtype.
+        TypeError: If the value is of an unsupported type.
+    """
     if value is None:  # pragma: no cover
         return {"dtype": "null", "ndim": 0}
 

--- a/src/plaid/storage/registry.py
+++ b/src/plaid/storage/registry.py
@@ -15,7 +15,18 @@ BACKENDS = {
 
 
 def get_backend(name: str) -> type[BackendModule]:
-    """Return backend module."""
+    """Return backend module.
+
+    Args:
+        name (str): The backend name; see :func:`available_backends` for the
+            available options.
+
+    Returns:
+        type[BackendModule]: The backend module class.
+
+    Raises:
+        ValueError: If ``name`` does not match any available backend.
+    """
     if name not in BACKENDS:
         raise ValueError(
             f"Error! backend '{name}' not available, option are: {list(BACKENDS.keys())}"


### PR DESCRIPTION
Thanks for contributing! Please make sure your PR title and content follow the guidelines.
Leave this checklist below in your PR description and tick the corresponding boxes.

### Checklist

- [x] Typing enforced
- [x] Documentation updated
- [x] Changelog updated
- [x] Tests and Example updates — not applicable: docstring-only change, no test updates needed
- [x] Coverage should be 100% — docstring-only change: no executable lines added (AST statement counts unchanged before/after)

### ✅ PR Title Format

📄 Documentation

---

### 📋 Description

Adds `Args`/`Returns`/`Raises` sections to the docstrings of core public APIs whose
summaries previously stated only the behaviour, following the Google style declared
in `ruff.toml` (`convention = "google"`) and the existing in-repo examples
(e.g. `storage/hf_datasets/bridge.py`, `infos.Infos.from_path`, `containers/utils.py`).

- `storage/backend_api.py`: all eight `BackendModule` protocol methods — the contract
  backend plugins implement, previously documented by a one-line summary only
- `infos.py`: the four `Infos` validation classmethods
- `containers/managers/default_manager.py`: the `FeaturesBackend` protocol methods
- `storage/registry.py`, `containers/utils.py`, `storage/common/preprocessor.py`: one
  function each

Each file follows its own established style: typed parameter lists where that is the
local convention (`repo_id (str): ...`), and untyped entries with ``code`` marking
where the file uses that (`infos.py`).

### What problem does it solve?

These are part of the API surface rendered on the public docs site (mkdocstrings with
`docstring_style = "google"`), but their summaries did not state the parameters,
return values, or raised errors; readers had to consult the implementations. All
existing sentences are preserved verbatim — only sections are added. No behaviour or
signatures change.

### How was it tested?

- `python -m py_compile` passes on all touched files
- AST statement counts are unchanged before/after each edit (no executable lines
  added, coverage unaffected)
- Every parameter is covered in the new `Args` sections (ruff `D417`-clean)

I have read and agree to the Contributor License Agreement in `CONTRIBUTING.md`.

---
*This contribution was prepared with AI assistance (a local LLM-based agent harness with deterministic checks and human review).*